### PR TITLE
Add ULL postfix to large number constants to avoid compile error on 32-bit systems

### DIFF
--- a/src/analytics/redis_processor_vizd.cc
+++ b/src/analytics/redis_processor_vizd.cc
@@ -63,7 +63,7 @@ RedisProcessorExec::UVEUpdate(RedisAsyncConnection * rac, RedisProcessorIf *rpi,
 
     if (agg == "stats") {
         std::string sc,sp,ss;
-        int64_t tsbin = (ts / 3600000000) * 3600000000;
+        int64_t tsbin = (ts / 3600000000ULL) * 3600000000ULL;
         std::ostringstream tsbinstr;
         tsbinstr << tsbin;
         std::string lhist = hist;


### PR DESCRIPTION
Add ULL postfix to large number constants to avoid compile error on 32-bit systems
