### PR TITLE
Object id query fails because the db_query->cfname was not set in the

### DIFF
--- a/src/query_engine/where_query.cc
+++ b/src/query_engine/where_query.cc
@@ -753,6 +753,12 @@ query_status_t WhereQuery::process_query()
     QE_TRACE(DEBUG, "Starting processing of " << sub_queries.size() <<
             " subqueries");
 
+    if (m_query->table == g_viz_constants.OBJECT_VALUE_TABLE) {
+        status_details = 0;
+        parent_query->subquery_processed(this);
+        return QUERY_SUCCESS;
+    }
+
     // invoke processing of all the sub queries
     // TBD: Handle ASYNC processing
     for (unsigned int i = 0; i < sub_queries.size(); i++)


### PR DESCRIPTION
WhereQuery constructor, if the table is ObjectValueTable.
We don't seem to be using where query result in the Select processing for
Object id query. Added code in the WhereQuery::process_query() to not do
any processing for Object id query.
