### PR TITLE
Take reference to source routing instance

### DIFF
--- a/src/bgp/routing-instance/service_chaining.cc
+++ b/src/bgp/routing-instance/service_chaining.cc
@@ -36,7 +36,7 @@ ServiceChain::ServiceChain(RoutingInstance *src, RoutingInstance *dest,
     : src_(src), dest_(dest), connected_(connected), connected_route_(NULL),
     service_chain_addr_(addr), connected_table_unregistered_(false),
     dest_table_unregistered_(false), connected_stopped_(false), dest_stopped_(false),
-    aggregate_(false) {
+    aggregate_(false), src_table_delete_ref_(this, src_table()->deleter()) {
     for(std::vector<std::string>::const_iterator it = subnets.begin();
         it != subnets.end(); it++) {
         error_code ec;

--- a/src/bgp/routing-instance/service_chaining.h
+++ b/src/bgp/routing-instance/service_chaining.h
@@ -10,6 +10,7 @@
 #include <set>
 
 #include <boost/shared_ptr.hpp>
+#include "base/lifetime.h"
 #include <base/queue_task.h>
 
 #include <sandesh/sandesh_types.h>
@@ -196,6 +197,10 @@ public:
         aggregate_ = true;
     }
 
+    void ManagedDelete() {
+        // Trigger of service chain delete is from config
+    }
+
 private:
     RoutingInstance *src_;
     RoutingInstance *dest_;
@@ -211,6 +216,7 @@ private:
     bool connected_stopped_;
     bool dest_stopped_;
     bool aggregate_; // Whether the host route needs to be aggregated
+    LifetimeRef<ServiceChain> src_table_delete_ref_;
 
     // Helper function to match 
     bool is_more_specific(BgpRoute *route, Ip4Prefix *aggregate_match);

--- a/src/bgp/testdata/service_chain_1.xml
+++ b/src/bgp/testdata/service_chain_1.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service-chain-info>
     <routing-instance>red</routing-instance>
+    <source-routing-instance>blue</source-routing-instance>
     <prefix>192.168.1.0/24</prefix>
     <prefix>192.168.2.0/24</prefix>
     <service-chain-address>1.1.2.3</service-chain-address>

--- a/src/bgp/testdata/service_chain_2.xml
+++ b/src/bgp/testdata/service_chain_2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service-chain-info>
     <routing-instance>red</routing-instance>
-    <source-routing-instance>blue-i1</source-routing-instance>
+    <source-routing-instance>blue</source-routing-instance>
     <prefix>192.168.0.0/16</prefix>
     <prefix>192.169.2.0/24</prefix>
     <service-chain-address>1.1.2.3</service-chain-address>

--- a/src/bgp/testdata/service_chain_3.xml
+++ b/src/bgp/testdata/service_chain_3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service-chain-info>
     <routing-instance>red</routing-instance>
-    <source-routing-instance>blue-i1</source-routing-instance>
+    <source-routing-instance>blue</source-routing-instance>
     <prefix>192.168.1.0/24</prefix>
     <prefix>192.169.2.0/24</prefix>
     <service-chain-address>1.1.2.3</service-chain-address>

--- a/src/bgp/testdata/service_chain_4.xml
+++ b/src/bgp/testdata/service_chain_4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <service-chain-info>
     <routing-instance>red</routing-instance>
-    <source-routing-instance>blue-i1</source-routing-instance>
+    <source-routing-instance>blue</source-routing-instance>
     <prefix>10.1.1.0/24</prefix>
     <service-chain-address>1.1.2.3</service-chain-address>
 </service-chain-info>


### PR DESCRIPTION
Bug fix for 2013.
When source routing instance(to search for connected route) and internal routing instance(where service chain info) is attached are different, reference is not taken on internal routing instance.
Add lifetime reference on src_table to ensure it is not deleted till SericeChain is referring to it.
