### PR TITLE
1975 - qed crash@in bool std::operator< <char, std::char_traits<char>

### DIFF
--- a/src/query_engine/post_processing.cc
+++ b/src/query_engine/post_processing.cc
@@ -38,7 +38,7 @@ bool PostProcessingQuery::sort_field_comparator(
         if ((*sort_it).type == std::string("int") || 
             (*sort_it).type == std::string("long") ||
             (*sort_it).type == std::string("ipv4")) {
-            uint64_t lhs_val, rhs_val;
+            uint64_t lhs_val = 0, rhs_val = 0;
             stringToInteger(lhs_it->second, lhs_val);
             stringToInteger(rhs_it->second, rhs_val);
             if (lhs_val < rhs_val) return true;


### PR DESCRIPTION
1975 - qed crash@in bool std::operator< <char, std::char_traits<char>
If cassandra returns empty columns for a key or if a select field is not present in the columns returned by cassandra, then an empty string is added for the column value.
In PostProcessingQuery::sort_field_comparator(), lhs_val and rhs_val are not initialized, resulting in junk value when the column value is empty string => stringToInteger() doesn’t update the lhs_val and rhs_val for invalid input. This causes std::sort() to access invalid memory resulting in segfault.

1659 - qed cored at SelectQuery::process_object_query_specific_select_params
If cassandra returns empty row for a key in object query, then the search for SANDESH_TYPE column in SelectQuery::process_object_query_specific_select_params() fails resulting in assert.
Added code to skip the row, if the column values returned by cassandra is empty.
