### PR TITLE
Patch in:

### DIFF
--- a/src/analytics/collector.h
+++ b/src/analytics/collector.h
@@ -22,6 +22,7 @@
 #include "viz_constants.h"
 #include "generator.h"
 #include <string>
+#include "collector_uve_types.h"
 
 class DbHandler;
 class Ruleeng;
@@ -69,12 +70,28 @@ public:
     unsigned short cassandra_port() { return cassandra_port_; }
     int analytics_ttl() { return analytics_ttl_; }
     int db_task_id();
+    const CollectorStats &GetStats() const { return stats_; }
 
 protected:
     virtual TcpSession *AllocSession(Socket *socket);
     virtual void DisconnectSession(SandeshSession *session);
 
 private:
+    void inline increment_no_session_error() {
+        stats_.no_session_error++;
+    }
+    void inline increment_no_generator_error() {
+        stats_.no_generator_error++;
+    }
+    void inline increment_session_mismatch_error() {
+        stats_.session_mismatch_error++;
+    }
+    void inline increment_redis_error() {
+        stats_.redis_error++;
+    }
+    void inline increment_sandesh_type_mismatch_error() {
+        stats_.sandesh_type_mismatch_error++;
+    }
 
     DbHandler *db_handler_;
     OpServerProxy * const osp_;
@@ -94,6 +111,7 @@ private:
     // Random generator for UUIDs
     tbb::mutex rand_mutex_;
     boost::uuids::random_generator umn_gen_;
+    CollectorStats stats_;
     static std::string prog_name_;
     static std::string self_ip_;
     static bool task_policy_set_;

--- a/src/analytics/collector_uve.sandesh
+++ b/src/analytics/collector_uve.sandesh
@@ -57,6 +57,10 @@ struct ModuleServerState {
     6: optional sandesh_uve.SandeshStateMachineStats sm_stats
     7: optional u64                        db_queue_count (aggtype="stats" hbin="50")
     8: optional u64                        db_enqueues
+    9: optional sandesh_uve.SandeshSessionStats session_stats
+    10: optional io.TcpServerSocketStats   session_rx_socket_stats
+    11: optional io.TcpServerSocketStats   session_tx_socket_stats
+    12: optional sandesh_uve.SandeshGeneratorStats  sm_msg_stats
 }
 
 uve sandesh SandeshModuleServerTrace {
@@ -66,7 +70,15 @@ uve sandesh SandeshModuleServerTrace {
 struct GeneratorSummaryInfo {
     1: string                              source
     2: string                              module_id    
-    3: string                              state    
+    3: string                              state
+}
+
+struct CollectorStats {
+    1: u64                                 no_session_error
+    2: u64                                 no_generator_error
+    3: u64                                 redis_error
+    4: u64                                 session_mismatch_error
+    5: u64                                 sandesh_type_mismatch_error
 }
 
 request sandesh ShowCollectorServerReq {
@@ -76,6 +88,7 @@ response sandesh ShowCollectorServerResp {
     1: io.TcpServerSocketStats             rx_socket_stats
     2: io.TcpServerSocketStats             tx_socket_stats
     3: list<GeneratorSummaryInfo>          generators
+    4: CollectorStats                      stats
 }
 
 // This struct is part of the CollectorInfo UVE. (key is hostname on which this

--- a/src/io/tcp_server.cc
+++ b/src/io/tcp_server.cc
@@ -375,29 +375,37 @@ void TcpServer::Connect(TcpSession *session, Endpoint remote) {
                     TcpSessionPtr(session), boost::asio::placeholders::error));
 }
 
-void TcpServer::GetRxSocketStats(TcpServerSocketStats &socket_stats) {
-    socket_stats.calls = stats_.read_calls;
-    socket_stats.bytes = stats_.read_bytes;
-    if (stats_.read_calls) {
-        socket_stats.average_bytes = stats_.read_bytes/stats_.read_calls;
+void TcpServer::SocketStats::GetRxStats(TcpServerSocketStats &socket_stats) const {
+    socket_stats.calls = read_calls;
+    socket_stats.bytes = read_bytes;
+    if (read_calls) {
+        socket_stats.average_bytes = read_bytes/read_calls;
     }
 }
 
-void TcpServer::GetTxSocketStats(TcpServerSocketStats &socket_stats) {
-    socket_stats.calls = stats_.write_calls;
-    socket_stats.bytes = stats_.write_bytes;
-    if (stats_.write_calls) {
-        socket_stats.average_bytes = stats_.write_bytes/stats_.write_calls;
+void TcpServer::GetRxSocketStats(TcpServerSocketStats &socket_stats) const {
+    stats_.GetRxStats(socket_stats);
+}
+
+void TcpServer::SocketStats::GetTxStats(TcpServerSocketStats &socket_stats) const {
+    socket_stats.calls = write_calls;
+    socket_stats.bytes = write_bytes;
+    if (write_calls) {
+        socket_stats.average_bytes = write_bytes/write_calls;
     }
-    socket_stats.blocked_count = stats_.write_blocked;
+    socket_stats.blocked_count = write_blocked;
     socket_stats.blocked_duration = duration_usecs_to_string(
-        stats_.write_blocked_duration_usecs);
-    if (stats_.write_blocked) {
+        write_blocked_duration_usecs);
+    if (write_blocked) {
         socket_stats.average_blocked_duration =
                  duration_usecs_to_string(
-                     stats_.write_blocked_duration_usecs/
-                     stats_.write_blocked);
+                     write_blocked_duration_usecs/
+                     write_blocked);
     }
+}
+
+void TcpServer::GetTxSocketStats(TcpServerSocketStats &socket_stats) const {
+    stats_.GetTxStats(socket_stats);
 }
 
 //

--- a/src/io/tcp_server.h
+++ b/src/io/tcp_server.h
@@ -66,6 +66,9 @@ class TcpServer {
             write_blocked_duration_usecs = 0;
         }
 
+        void GetRxStats(TcpServerSocketStats &socket_stats) const;
+        void GetTxStats(TcpServerSocketStats &socket_stats) const;
+
         tbb::atomic<uint64_t> read_calls;
         tbb::atomic<uint64_t> read_bytes;
         tbb::atomic<uint64_t> write_calls;
@@ -94,8 +97,8 @@ class TcpServer {
     // wait until the server has deleted all sessions.
     void WaitForEmpty();
 
-    void GetRxSocketStats(TcpServerSocketStats &socket_stats);
-    void GetTxSocketStats(TcpServerSocketStats &socket_stats);
+    void GetRxSocketStats(TcpServerSocketStats &socket_stats) const;
+    void GetTxSocketStats(TcpServerSocketStats &socket_stats) const;
 
   protected:
     // Create a session object.

--- a/src/io/tcp_session.cc
+++ b/src/io/tcp_session.cc
@@ -642,3 +642,11 @@ error_code TcpSession::SetSocketOptions() {
 
     return ec;
 }
+
+void TcpSession::GetRxSocketStats(TcpServerSocketStats &socket_stats) const {
+    stats_.GetRxStats(socket_stats);
+}
+
+void TcpSession::GetTxSocketStats(TcpServerSocketStats &socket_stats) const {
+    stats_.GetTxStats(socket_stats);
+}

--- a/src/io/tcp_session.h
+++ b/src/io/tcp_session.h
@@ -129,6 +129,8 @@ class TcpSession {
     void AsyncReadStart();
 
     const TcpServer::SocketStats &GetSocketStats() const { return stats_; }
+    void GetRxSocketStats(TcpServerSocketStats &socket_stats) const;
+    void GetTxSocketStats(TcpServerSocketStats &socket_stats) const;
 
   protected:
     virtual ~TcpSession();

--- a/src/query_engine/query.h
+++ b/src/query_engine/query.h
@@ -75,7 +75,6 @@
 #include "base/logging.h"
 #include <sandesh/sandesh_types.h>
 #include <sandesh/sandesh.h>
-#include <sandesh/sandesh_session.h>
 #include <sandesh/sandesh_constants.h>
 #include <sandesh/sandesh_ctrl_types.h>
 #include <sandesh/sandesh_trace.h>


### PR DESCRIPTION
commit cb9122cf6ea3c117f2e6df39da63629b3f6e7551
Author: Megh Bhatt meghb@juniper.net
Date:   Thu Nov 21 20:40:55 2013 -0800

```
1. Add collector sandesh message and socket statistics on per
   generator basis
2. Add collector error counters
3. Send sandesh client socket statistics in UVE
4. pep8 compliance for sandesh_req_impl.py
5. Cleanup sandesh message statistics structure in sandesh_uve
```

commit bbf01f04c15deb549f4c76d34c6dabc6b3fb2f24
Author: Megh Bhatt meghb@juniper.net
Date:   Wed Nov 20 15:10:30 2013 -0800

```
Generator Db connect timer and disconnect session can be called
from concurrent threads and hence generator session can be NULL
when Db connect init is called from the timer expiry. Fix is to
add a disconnected flag which is set when disconnect session is
called and not do Db connect init if generator is disconnected.
Fixed couple of places in collector where generator disconnect
session was not being called.
```
