### PR TITLE
    1) HttpConnection object was enqueued for deletion twice in case of ...

### DIFF
--- a/src/discovery/client/discovery_client.h
+++ b/src/discovery/client/discovery_client.h
@@ -53,6 +53,8 @@ struct DSResponseHeader {
     int sub_sent_;
     int sub_rcvd_;
     int sub_ttl_sent_;
+
+    bool subscribe_cb_called_;
 };
 
 #define MAX_HB_SIZE 16
@@ -96,6 +98,8 @@ struct DSPublishResponse {
     int pub_hb_sent_;
     int pub_hb_fail_;
     int pub_hb_rcvd_;
+
+    bool publish_cb_called_;
 };
 
 typedef boost::function<void()> EnqueuedCb;

--- a/src/discovery/client/discovery_client.sandesh
+++ b/src/discovery/client/discovery_client.sandesh
@@ -12,3 +12,10 @@ systemlog sandesh DiscoveryClientLog {
     1: string serviceName; 
     2: string msg;
 }
+
+trace sandesh DiscoveryClientErrorMsg {
+    1: string type;
+    2: string serviceName;
+    3: "Curl Errorcode:";
+    4: i32 errorcode;
+}

--- a/src/http/client/http_curl.cc
+++ b/src/http/client/http_curl.cc
@@ -69,15 +69,11 @@ static void mcode_or_die(const char *where, CURLMcode code)
     case CURLM_INTERNAL_ERROR:     s="CURLM_INTERNAL_ERROR";     break;
     case CURLM_UNKNOWN_OPTION:     s="CURLM_UNKNOWN_OPTION";     break;
     case CURLM_LAST:               s="CURLM_LAST";               break;
-    default: s="CURLM_unknown";
-      break;
-    case     CURLM_BAD_SOCKET:         s="CURLM_BAD_SOCKET";
-      /* ignore this error */
-      return;
+    case CURLM_BAD_SOCKET:         s="CURLM_BAD_SOCKET";         break;
+    default:                       s="CURLM_unknown";            break;
     }
 
     fprintf(MSG_OUT, "\nERROR: %s returns %s", where, s);
-    exit(code);
   }
 }
 
@@ -99,20 +95,10 @@ static void check_multi_info(GlobalInfo *g)
       res = msg->data.result;
       curl_easy_getinfo(easy, CURLINFO_PRIVATE, &conn);
       curl_easy_getinfo(easy, CURLINFO_EFFECTIVE_URL, &eff_url);
-      if (res != CURLE_OK) {
-          boost::system::error_code error(res, boost::system::system_category());
-          std::string empty_str("");
-          conn->connection->HttpClientCb()(empty_str, error);
-      }
-      if (conn->connection->curl_handle()) {
-          curl_multi_remove_handle(g->multi, easy);
-          curl_slist_free_all(conn->headers);
-          free(conn->post);
-          free(conn->url);
-          curl_easy_cleanup(easy);
-          conn->connection->set_curl_handle(NULL);
-          free(conn);
-      }
+
+      boost::system::error_code error(res, boost::system::system_category());
+      std::string empty_str("");
+      conn->connection->HttpClientCb()(empty_str, error);
     }
   }
 }


### PR DESCRIPTION
...write-cb (read from socket)

```
   followed by a socket error. Use socket transfer done indication from client library to
   enqueue HttpConnection object delete.
2) mcode_or_die remove exit from the the code, consecutive calls detect socket errors and inform
   the clients.
3) Initiate a resubscribe/republish on paring xml failure error.
4) Discovery client registers for write_cb when <body> of an HTML response is recieved, when
   only <header> is received(not expected) this should be considered as an error case and trigger resubscribe
   or republish. This is done by marking the write_cb.
```
