### PR TITLE
This bug is opened to provide relative query start time and end time. Th...

### DIFF
--- a/src/opserver/opserver.py
+++ b/src/opserver/opserver.py
@@ -111,8 +111,8 @@ def redis_query_status(host, port, qid):
     if int(ttl) != -1:
         chunk_resp["ttl"] = int(ttl)
     query_time = redish.hmget("QUERY:" + qid, ["start_time", "end_time"])
-    chunk_resp["start_time"] = int(query_time[0])
-    chunk_resp["end_time"] = int(query_time[1])
+    chunk_resp["start_time"] = query_time[0]
+    chunk_resp["end_time"] = query_time[1]
     if chunk_resp["progress"] == 100:
         chunk_resp["href"] = "/analytics/query/%s/chunk-final/%d" % (qid, 0)
     chunks.append(chunk_resp)

--- a/src/query_engine/query.h
+++ b/src/query_engine/query.h
@@ -838,6 +838,7 @@ const std::vector<boost::shared_ptr<QEOpServerProxy::BufferT> >& inputs,
     std::string get_column_field_datatype(const std::string& col_field);
     bool is_flow_query(); // either flow-series or flow-records query
     bool is_query_parallelized() { return parallelize_query_; }
+    uint64_t parse_time(const std::string& relative_time);
 
     private:
     bool parallelize_query_;


### PR DESCRIPTION
...e relative time can take values in the following format:

Now, now+10s,now+10m,now+10h,now-10s,now-10m,now-10h.
Diff Dummary:
1) We are retaining the same "start_time" and "end_time" to specify even the relative time 2)In opserver.py, start_time and end_time and converted to int in redis_query_status().Change has been made to retain them as string.
3) change has been made in calculation of time_slice. ^ operator was used instead of power() for exponent calculation, so replaced that as well.
