### PR TITLE
Patch in:

### DIFF
--- a/src/gendb/gendb_if.h
+++ b/src/gendb/gendb_if.h
@@ -21,6 +21,15 @@ namespace GenDb {
 
 /* New stuff */
 typedef boost::variant<std::string, uint64_t, uint32_t, boost::uuids::uuid, uint8_t, uint16_t, double> DbDataValue;
+enum DbDataValueType {
+    DB_VALUE_STRING = 0,
+    DB_VALUE_UINT64 = 1,
+    DB_VALUE_UINT32 = 2,
+    DB_VALUE_UUID = 3,
+    DB_VALUE_UINT8 = 4,
+    DB_VALUE_UINT16 = 5,
+    DB_VALUE_DOUBLE = 6,
+};    
 typedef std::vector<DbDataValue> DbDataValueVec;
 typedef std::vector<GenDb::DbDataType::type> DbDataTypeVec;
 

--- a/src/query_engine/select.cc
+++ b/src/query_engine/select.cc
@@ -609,7 +609,8 @@ query_status_t SelectQuery::process_query() {
                         }
                     } else {
                         // do not assert, append an empty string
-                    cmap.insert(std::make_pair(*jt, std::string(""))); }
+                        cmap.insert(std::make_pair(*jt, std::string("")));
+                    }
                 } else if (*jt == g_viz_constants.UUID_KEY) {
 
                     boost::uuids::uuid u;
@@ -623,50 +624,49 @@ query_status_t SelectQuery::process_query() {
                     std::copy(u.begin(), u.end(), u_s.begin());
 
                     cmap.insert(std::make_pair(kt->first, u_s));
-                } else if ((*jt == g_viz_constants.SOURCE) ||
-                        (*jt == g_viz_constants.SOURCE) ||
-                        (*jt == g_viz_constants.NAMESPACE) ||
-                        (*jt == g_viz_constants.MODULE) ||
-                        (*jt == g_viz_constants.CONTEXT) ||
-                        (*jt == g_viz_constants.CATEGORY) ||
-                        (*jt == g_viz_constants.MESSAGE_TYPE) ||
-                        (*jt == g_viz_constants.DATA)) {
-                    std::string val;
-                    try {
-                        val = boost::get<std::string>(kt->second);
-                    } catch (boost::bad_get& ex) {
-                        QE_ASSERT(0);
-                    }
-                    cmap.insert(std::make_pair(kt->first, val));
-                } else if (*jt == g_viz_constants.TIMESTAMP) {
-                    uint64_t val;
-                    try {
-                        val = boost::get<uint64_t>(kt->second);
-                    } catch (boost::bad_get& ex) {
-                        QE_ASSERT(0);
-                    }
-                    cmap.insert(std::make_pair(kt->first, integerToString(val)));
-                } else if ((*jt == g_viz_constants.LEVEL) ||
-                        (*jt == g_viz_constants.SEQUENCE_NUM) ||
-                        (*jt == g_viz_constants.VERSION)) {
-                    uint32_t val;
-                    try {
-                        val = boost::get<uint32_t>(kt->second);
-                    } catch (boost::bad_get& ex) {
-                        QE_ASSERT(0);
-                    }
-                    cmap.insert(std::make_pair(kt->first, integerToString(val)));
-                } else if (*jt == g_viz_constants.SANDESH_TYPE) {
-                    uint8_t val;
-                    try {
-                        val = boost::get<uint8_t>(kt->second);
-                    } catch (boost::bad_get& ex) {
-                        QE_ASSERT(0);
-                    }
-                    cmap.insert(std::make_pair(kt->first, integerToString(val)));
                 } else {
-                    QE_ASSERT(0); // Valid assert, this will be a bug
-                }
+                    std::string vstr;
+                    switch (kt->second.which()) {
+                    case GenDb::DB_VALUE_STRING: {
+                        vstr = boost::get<std::string>(kt->second);
+                        break;
+                    }
+                    case GenDb::DB_VALUE_UINT64: {
+                        uint64_t vint = boost::get<uint64_t>(kt->second);
+                        vstr = integerToString(vint);
+                        break;
+                    }     
+                    case GenDb::DB_VALUE_UINT32: {
+                        uint32_t vint = boost::get<uint32_t>(kt->second);
+                        vstr = integerToString(vint);
+                        break;
+                    }     
+                    case GenDb::DB_VALUE_UINT16: {
+                        uint16_t vint = boost::get<uint16_t>(kt->second);
+                        vstr = integerToString(vint);
+                        break;
+                    }     
+                    case GenDb::DB_VALUE_UINT8: {
+                        uint8_t vint = boost::get<uint8_t>(kt->second);
+                        vstr = integerToString(vint);
+                        break;
+                    }     
+                    case GenDb::DB_VALUE_UUID: {
+                        boost::uuids::uuid vuuid = boost::get<boost::uuids::uuid>(kt->second);
+                        vstr = to_string(vuuid); 
+                        break;
+                    }
+                    case GenDb::DB_VALUE_DOUBLE: {
+                        double vdouble = boost::get<double>(kt->second);
+                        vstr = integerToString(vdouble);
+                        break;
+                    } 
+                    default:
+                        QE_ASSERT(0);
+                        break;
+                    }
+                    cmap.insert(std::make_pair(kt->first, vstr));
+                } 
             }
             if (jt == select_column_fields.end()) {
                 result_->push_back(std::make_pair(cmap, nullmetadata));


### PR DESCRIPTION
commit a9e6a9a7c028f328d201b1e68a309e7258c0f3d2
Author: Megh Bhatt meghb@juniper.net
Date:   Fri Nov 22 01:11:33 2013 -0800

```
1. Remove code that looks at column name to determine the data type
   stored in cassandra in query engine.
2. Install contrail-nodemgr in the control, config, analytics,
   and vrouter venv from the respective rpms instead of from
   the supervisor rpm to support upgrade of individual
   rpms
```
