### PR TITLE
Configure CURLOPT_CONNECTTIMEOUT 

### DIFF
--- a/src/http/client/http_curl.cc
+++ b/src/http/client/http_curl.cc
@@ -354,6 +354,7 @@ ConnInfo *new_conn(HttpConnection *connection, GlobalInfo *g,
   curl_easy_setopt(conn->easy, CURLOPT_NOPROGRESS, 1L);
   curl_easy_setopt(conn->easy, CURLOPT_PROGRESSFUNCTION, prog_cb);
   curl_easy_setopt(conn->easy, CURLOPT_PROGRESSDATA, conn);
+  curl_easy_setopt(conn->easy, CURLOPT_CONNECTTIMEOUT, 4L); // in secs
   if (timeout) {
       /* set the timeout limits to abort the connection */
       curl_easy_setopt(conn->easy, CURLOPT_LOW_SPEED_TIME, 3L);


### PR DESCRIPTION
Configure CURLOPT_CONNECTTIMEOUT for libcurl library which will close th.e TCP connection

and trigger the callback registered by the application.

Minumum connect timeout is tcp syn retries on the system, setting the connect
timeout to a low value ensures the callback is triggered after the system
timeout if connect fails.

Note if the CURLOPT_CONNECTTIMEOUT parameter is not configured it waits indefinelty.
