### PR TITLE
Get bgp_update_rx_test to pass cleanly.

### DIFF
--- a/src/bgp/bgp_config.cc
+++ b/src/bgp/bgp_config.cc
@@ -29,6 +29,7 @@ BgpNeighborConfig::AddressFamilyList
 
 void BgpNeighborConfig::Initialize() {
     default_addr_family_list_.push_back("inet");
+    default_addr_family_list_.push_back("inet-vpn");
 }
 
 MODULE_INITIALIZER(BgpNeighborConfig::Initialize);

--- a/src/bgp/test/bgp_config_test.cc
+++ b/src/bgp/test/bgp_config_test.cc
@@ -1311,8 +1311,9 @@ TEST_F(BgpConfigTest, AddressFamilies3) {
     BgpPeer *peer = rti->peer_manager()->PeerFind("10.1.1.1");
     TASK_UTIL_ASSERT_TRUE(peer != NULL);
 
-    TASK_UTIL_EXPECT_EQ(1, peer->families().size());
+    TASK_UTIL_EXPECT_EQ(2, peer->families().size());
     TASK_UTIL_EXPECT_TRUE(peer->LookupFamily(Address::INET));
+    TASK_UTIL_EXPECT_TRUE(peer->LookupFamily(Address::INETVPN));
 
     boost::replace_all(content, "<config>", "<delete>");
     boost::replace_all(content, "</config>", "</delete>");


### PR DESCRIPTION
Problem was that the test sent both inet and inet-vpn prefixes
to a test BgpPeer, but the inet-vpn NLRI is rejected since the
address family is not configured locally on the peer.  We used
to only check the capabilities in the received Open message to
decided whether to process an NLRI earlier.  However a recent
change also checks the local configuration, thus causing the
test to fail.

Fixed by changing the hard coded default address families for
a peer from inet to (inet, inet-vpn). Tweak bgp_config_test to
match the new default address family list.
