### PR TITLE
Enhancing Flow Audit to do faster cleanup of Hold Entries.

### DIFF
--- a/src/vnsw/agent/ksync/flowtable_ksync.cc
+++ b/src/vnsw/agent/ksync/flowtable_ksync.cc
@@ -35,7 +35,7 @@
 FlowTableKSyncObject *FlowTableKSyncObject::singleton_;
 
 FlowTableKSyncObject::FlowTableKSyncObject() : 
-    KSyncObject(), audit_flow_idx_(0),
+    KSyncObject(), audit_flow_idx_(0), audit_timestamp_(0),
     audit_timer_(TimerManager::CreateTimer
                  (*(Agent::GetInstance()->GetEventManager())->io_service(),
                   "Flow Audit Timer",
@@ -45,7 +45,7 @@ FlowTableKSyncObject::FlowTableKSyncObject() :
 }
 
 FlowTableKSyncObject::FlowTableKSyncObject(int max_index) :
-    KSyncObject(max_index), audit_flow_idx_(0),
+    KSyncObject(max_index), audit_flow_idx_(0), audit_timestamp_(0),
     audit_timer_(TimerManager::CreateTimer
                  (*(Agent::GetInstance()->GetEventManager())->io_service(),
                   "Flow Audit Timer",
@@ -452,7 +452,7 @@ void FlowTableKSyncObject::MapFlowMemTest() {
     flow_table_ = KSyncSockTypeMap::FlowMmapAlloc(kTestFlowTableSize);
     memset(flow_table_, 0, kTestFlowTableSize);
     flow_table_entries_ = kTestFlowTableSize / sizeof(vr_flow_entry);
-    audit_yeild_ = flow_table_entries_;
+    audit_yield_ = flow_table_entries_;
 }
 
 void FlowTableKSyncObject::UnmapFlowMemTest() {
@@ -462,10 +462,10 @@ void FlowTableKSyncObject::UnmapFlowMemTest() {
 bool FlowTableKSyncObject::AuditProcess(FlowTableKSyncObject *obj) {
     uint32_t flow_idx;
     const vr_flow_entry *vflow_entry;
-    uint64_t curr_time = UTCTimestampUsec();
+    obj->audit_timestamp_ += AuditYieldTimer;
     while (!obj->audit_flow_list_.empty()) {
         std::pair<uint32_t, uint64_t> list_entry = obj->audit_flow_list_.front();
-        if ((curr_time - list_entry.second) < AuditTimeout) {
+        if ((obj->audit_timestamp_ - list_entry.second) < AuditTimeout) {
             /* Wait for AuditTimeout to create short flow for the entry */
             break;
         }
@@ -500,12 +500,12 @@ bool FlowTableKSyncObject::AuditProcess(FlowTableKSyncObject *obj) {
     }
 
     int count = 0;
-    assert(obj->audit_yeild_);
-    while (count < obj->audit_yeild_) {
+    assert(obj->audit_yield_);
+    while (count < obj->audit_yield_) {
         vflow_entry = obj->GetKernelFlowEntry(obj->audit_flow_idx_, false);
         if (vflow_entry && vflow_entry->fe_action == VR_FLOW_ACTION_HOLD) {
             obj->audit_flow_list_.push_back(std::make_pair(obj->audit_flow_idx_,
-                                                           curr_time));
+                                                           obj->audit_timestamp_));
         }
 
         count++;
@@ -593,8 +593,8 @@ void FlowTableKSyncObject::MapFlowMem() {
     }
 
     flow_table_entries_ = flow_table_size_ / sizeof(vr_flow_entry);
-    audit_yeild_ = AuditYeild;
-    singleton_->audit_timer_->Start(AuditYeildTimer,
+    audit_yield_ = AuditYield;
+    singleton_->audit_timer_->Start(AuditYieldTimer,
                                     boost::bind(&FlowTableKSyncObject::AuditProcess, singleton_));
     return;
 }

--- a/src/vnsw/agent/ksync/flowtable_ksync.h
+++ b/src/vnsw/agent/ksync/flowtable_ksync.h
@@ -80,9 +80,9 @@ private:
 class FlowTableKSyncObject : public KSyncObject {
 public:
     static const int kTestFlowTableSize = 131072 * sizeof(vr_flow_entry);
-    static const uint32_t AuditYeildTimer = 500;         // in msec
-    static const uint32_t AuditTimeout = 2000000;    // in usec
-    static const int AuditYeild = 1024;
+    static const uint32_t AuditYieldTimer = 500;         // in msec
+    static const uint32_t AuditTimeout = 2000;           // in msec
+    static const int AuditYield = 1024;
 
     FlowTableKSyncObject();
     FlowTableKSyncObject(int max_index);
@@ -131,8 +131,9 @@ private:
     vr_flow_req flow_req_;
     vr_flow_entry *flow_table_;
     uint32_t flow_table_entries_;
-    int audit_yeild_;
+    int audit_yield_;
     uint32_t audit_flow_idx_;
+    uint64_t audit_timestamp_;
     std::list<std::pair<uint32_t, uint64_t> > audit_flow_list_;
     Timer *audit_timer_;
     DISALLOW_COPY_AND_ASSIGN(FlowTableKSyncObject);


### PR DESCRIPTION
loop through 1K entries every 500 ms so that scan of flow table
is finished in 4 mins 16 secs, compared to 17 mins.
