### PR TITLE
UT for #2094

### DIFF
--- a/src/opserver/test/analytics_systest.py
+++ b/src/opserver/test/analytics_systest.py
@@ -161,6 +161,19 @@ class AnalyticsTest(testtools.TestCase, fixtures.TestWithFixtures):
         assert generator_obj.verify_vm_uve(vm_id='abcd',
                                            num_vm_ifs=5,
                                            msg_count=5)
+        # Delete the VM UVE and verify that the deleted flag is set
+        # in the UVE cache
+        generator_obj.delete_vm_uve('abcd')
+        assert generator_obj.verify_vm_uve_cache(vm_id='abcd', delete=True)
+        # Add the VM UVE with the same vm_id and verify that the deleted flag
+        # is cleared in the UVE cache
+        generator_obj.send_vm_uve(vm_id='abcd',
+                                  num_vm_ifs=5,
+                                  msg_count=5)
+        assert generator_obj.verify_vm_uve_cache(vm_id='abcd')
+        assert generator_obj.verify_vm_uve(vm_id='abcd',
+                                           num_vm_ifs=5,
+                                           msg_count=5)
         return True
     # end test_03_vm_uve
 

--- a/src/opserver/test/utils/generator_introspect_utils.py
+++ b/src/opserver/test/utils/generator_introspect_utils.py
@@ -26,4 +26,10 @@ class VerificationGenerator(VerificationUtilBase):
         return EtreeToDict(xpath).get_all_entry(p)
     #end get_collector_connection_status
 
+    def get_uve(self, tname):
+        path = 'Snh_SandeshUVECacheReq?x=%s' % (tname)
+        xpath = './/' + tname
+        p = self.dict_get(path)
+        return EtreeToDict(xpath).get_all_entry(p)
+    #end get_uve
 #end class VerificationGenerator


### PR DESCRIPTION
When the VN is deleted, the "deleted" flag in the VN UVE is set to True and is updated in the UVE cache. When the deleted VN is recreated, the "deleted" flag is not set (None). The code expects the "deleted" flag to be set to False and hence the VN is not updated in the cache. 
