### PR TITLE
o ssl.h (SSL_library_init) is deprecated, as reported by clang.

### DIFF
--- a/src/ifmap/client/test/boost_ssl_client.cc
+++ b/src/ifmap/client/test/boost_ssl_client.cc
@@ -6,13 +6,12 @@
 #include <ctime>
 
 using namespace std;
-using boost::system::error_code;
 
 BoostSslClient::BoostSslClient(boost::asio::io_service &io_service)
-    : io_service_(io_service), resolver_(io_service),
+    : resolver_(io_service),
       context_(io_service, boost::asio::ssl::context::sslv3_client),
       socket_(io_service, context_) {
-    error_code ec;
+    boost::system::error_code ec;
     context_.set_verify_mode(boost::asio::ssl::context::verify_none, ec);
 }
 

--- a/src/ifmap/client/test/boost_ssl_client.h
+++ b/src/ifmap/client/test/boost_ssl_client.h
@@ -14,7 +14,6 @@
 #include <boost/asio/placeholders.hpp>
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
-#include <boost/asio/ssl.hpp>
 #include "boost/generator_iterator.hpp"
 #include "boost/random.hpp"
 #include <boost/system/error_code.hpp>
@@ -58,7 +57,6 @@ public:
 private:
     void BuildPollRequest(std::ostringstream& poll_msg);
 
-    boost::asio::io_service& io_service_;
     boost::asio::ip::tcp::resolver resolver_;
     boost::asio::ssl::context context_;
     SslStream socket_;

--- a/src/ifmap/client/test/boost_ssl_server.cc
+++ b/src/ifmap/client/test/boost_ssl_server.cc
@@ -4,8 +4,6 @@
 
 #include "boost_ssl_server.h"
 
-using boost::system::error_code;
-
 BoostSslServer::BoostSslServer(boost::asio::io_service& io_service,
                                unsigned short port, string password)
     : io_service_(io_service),
@@ -14,7 +12,7 @@ BoostSslServer::BoostSslServer(boost::asio::io_service& io_service,
       context_(io_service, boost::asio::ssl::context::sslv3_server),
       password_(password) {
 
-    error_code ec;
+    boost::system::error_code ec;
     context_.set_verify_mode(boost::asio::ssl::context::verify_none, ec);
     context_.use_certificate_chain_file(
         "controller/src/ifmap/client/test/server.pem");

--- a/src/ifmap/client/test/boost_ssl_server.h
+++ b/src/ifmap/client/test/boost_ssl_server.h
@@ -13,7 +13,6 @@
 #include <boost/asio/placeholders.hpp>
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
-#include <boost/asio/ssl.hpp>
 #include <boost/assign/list_of.hpp>
 #include "boost/generator_iterator.hpp"
 #include "boost/random.hpp"


### PR DESCRIPTION
o error_code is also defined in std namespace
