### PR TITLE
Compilation of sources which include buildinfo.h should be dependent on ...

### DIFF
--- a/src/analytics/SConscript
+++ b/src/analytics/SConscript
@@ -92,7 +92,7 @@ AnalyticsEnv['ANALYTICS_VIZ_SANDESH_GEN_OBJS'] = AnalyticsEnv.Object(AnalyticsVi
 OpServerProxy_obj = AnalyticsEnv.Object('OpServerProxy.o', 'OpServerProxy.cc')
 db_handler_obj = AnalyticsEnv_excep.Object('db_handler.o', 'db_handler.cc')
 main_obj = AnalyticsEnv_excep.Object('main.o', 'main.cc')
-#AnalyticsEnv_excep.Depends(main_obj, 'buildinfo.cc')
+AnalyticsEnv_excep.Depends(main_obj, 'buildinfo.cc')
 
 buildinfo_dep_libs = ['../base/libcpuinfo.a', '../../lib/libsandesh.a', '../../lib/libhttp.a', '../../lib/libhttp_parser.a', 
                       '../../lib/libcurl.a', '../gendb/libgendb.a', '../../lib/libthrift.a', '../cdb/libcdb.a', 

--- a/src/vnsw/agent/cmn/SConscript
+++ b/src/vnsw/agent/cmn/SConscript
@@ -63,5 +63,7 @@ env.GenerateBuildInfoCode(
     path=str(Dir('.').abspath))
 
 vnswcmn = env.Library('vnswcmn', ['buildinfo.cc'] + vnswcmn_sources)
+env.Depends('agent_cmn.o', 'buildinfo.cc')
+env.Depends('../main.o', 'buildinfo.cc')
 
 env.SConscript('test/SConscript', exports='AgentEnv', duplicate = 0)


### PR DESCRIPTION
...target which generates buildinfo.h
