### PR TITLE
Change so that we can print time-ago instead of absolute time for the

### DIFF
--- a/src/ifmap/client/ifmap_state_machine.cc
+++ b/src/ifmap/client/ifmap_state_machine.cc
@@ -967,7 +967,7 @@ const std::string &IFMapStateMachine::LastStateName() const {
 }
 
 const std::string IFMapStateMachine::last_state_change_at() const {
-    return integerToString(UTCUsecToPTime(last_state_change_at_));
+    return duration_usecs_to_string(UTCTimestampUsec() - last_state_change_at_);
 }
 
 void IFMapStateMachine::set_last_event(const std::string &event) { 
@@ -976,5 +976,5 @@ void IFMapStateMachine::set_last_event(const std::string &event) {
 }
 
 const std::string IFMapStateMachine::last_event_at() const {
-    return integerToString(UTCUsecToPTime(last_event_at_));
+    return duration_usecs_to_string(UTCTimestampUsec() - last_event_at_);
 }


### PR DESCRIPTION
state-machine variables.  All other times being printed are of time-ago
variety.
