### PR TITLE
Ignore DB requests from down/deleted peers.

### DIFF
--- a/src/bgp/bgp_table.cc
+++ b/src/bgp/bgp_table.cc
@@ -242,9 +242,6 @@ void BgpTable::InputCommon(DBTablePartBase *root, BgpRoute *rt, BgpPath *path,
     switch (oper) {
     case DBRequest::DB_ENTRY_ADD_CHANGE: {
 
-        // Skip if this peer is down/deleted.
-        if (peer && !peer->IsReady()) return;
-
         assert(rt);
 
         // The entry may currently be marked as deleted.
@@ -315,6 +312,10 @@ void BgpTable::Input(DBTablePartition *root, DBClient *client,
         (static_cast<RequestKey *>(req->key.get()))->GetPeer();
     RequestData *data = static_cast<RequestData *>(req->data.get());
     BgpPath *path = NULL;
+
+    // Skip if this peer is down/deleted.
+    if (peer && !peer->IsReady())
+        return;
 
     // First mark all paths from this request source as deleted.
     // Apply all paths provided in this request data and add them. If path


### PR DESCRIPTION
The old code used to add a BgpRoute from BgpTable::Input when we
received a add/change request. BgpTable::InputCommon would ignore
the request and not add a BgpPath if the request was from a peer
that's down/deleted.  This could create a scenario where we have
a BgpRoute without any BgpPaths.

Move the check for down/deleted peer from BgpTable::InputCommon
to BgpTable::Input.

Thanks to Prakash for identifying this scenario.
