### PR TITLE
Patch in: e9572f3e8e78ca5ce44b7e0ec84568dea97adb8c

### DIFF
--- a/src/analytics/collector.cc
+++ b/src/analytics/collector.cc
@@ -174,6 +174,7 @@ TcpSession* Collector::AllocSession(Socket *socket) {
     VizSession *session = new VizSession(this, socket, AllocConnectionIndex(), 
                                          session_writer_task_id(),
                                          session_reader_task_id());
+    session->SetBufferSize(kDefaultSessionBufferSize);
     return session;
 }
 

--- a/src/analytics/collector.h
+++ b/src/analytics/collector.h
@@ -121,6 +121,7 @@ private:
     static std::string self_ip_;
     static bool task_policy_set_;
     static const std::vector<DbHandler::DbQueueWaterMarkInfo> kDbQueueWaterMarkInfo;
+    static const int kDefaultSessionBufferSize = 16 * 1024;
 
     DISALLOW_COPY_AND_ASSIGN(Collector);
 };

--- a/src/io/tcp_session.cc
+++ b/src/io/tcp_session.cc
@@ -649,3 +649,7 @@ void TcpSession::GetRxSocketStats(TcpServerSocketStats &socket_stats) const {
 void TcpSession::GetTxSocketStats(TcpServerSocketStats &socket_stats) const {
     stats_.GetTxStats(socket_stats);
 }
+
+void TcpSession::SetBufferSize(int buffer_size) {
+    buffer_size_ = buffer_size;
+}

--- a/src/io/tcp_session.h
+++ b/src/io/tcp_session.h
@@ -68,6 +68,8 @@ class TcpSession {
 
     virtual std::string ToString() const { return name_; }
 
+    void SetBufferSize(int buffer_size);
+
     // Getters and setters
     Socket *socket() { return socket_.get(); }
 


### PR DESCRIPTION
commit e9572f3e8e78ca5ce44b7e0ec84568dea97adb8c
Author: Megh Bhatt meghb@juniper.net
Date:   Mon Dec 30 16:51:38 2013 -0800

```
1. Change TCP session reader task for vizd from the sandesh state
   machine task to the IO reader task so that the sandesh message
   reading and processing can happen in parallel. This reverts the
   change done as part of bug 1729 to make the session reader task
   and state machine task exclusive. The issue mentioned in bug
   1729 is handled by setting the session sandesh message receive
   callback to NULL as part of session delete/close which happens
   from the state machine task.
2. Increase the VizSession receive buffer size to 16K from 4K
   since the Sandesh client average send is around 10K bytes.

With the above 2 changes, on a single box setup, vizd is able to
receive 50K flow samples at steady state with no drops on the sandesh
client.
```
