### PR TITLE
Patch in: fed1a401607ed31781d0668be540ecc3e9356f78

### DIFF
--- a/src/analytics/redis_connection.cc
+++ b/src/analytics/redis_connection.cc
@@ -32,7 +32,6 @@ RedisAsyncConnection::RedisAsyncConnection(EventManager *evm, const std::string 
     callbackFailed_(0),
     callbackSucceeded_(0),
     context_(NULL),
-    client_(NULL),
     state_(REDIS_ASYNC_CONNECTION_INIT),
     reconnect_timer_(*evm->io_service()),
     client_connect_cb_(client_connect_cb),
@@ -60,8 +59,6 @@ RedisAsyncConnection::~RedisAsyncConnection() {
       }
       redisAsyncDisconnect(context_);
     }    
-    if (client_)
-        delete client_;
     reconnect_timer_.cancel(ec);
 }
 
@@ -194,7 +191,7 @@ bool RedisAsyncConnection::RAC_Connect(void) {
         return true;
     }
 
-    client_ = (new redisBoostClient(*evm_->io_service(), context_, mutex_));
+    client_.reset(new redisBoostClient(*evm_->io_service(), context_, mutex_));
 
     tbb::mutex::scoped_lock fns_lock(rac_cb_fns_map_mutex_);
 

--- a/src/analytics/redis_connection.h
+++ b/src/analytics/redis_connection.h
@@ -91,7 +91,7 @@ private:
 
     redisAsyncContext *context_;
     //boost::scoped_ptr<redisBoostClient> client_;
-    redisBoostClient *client_;
+    boost::shared_ptr<redisBoostClient> client_;
     tbb::mutex mutex_;
     RedisState state_;
     boost::asio::deadline_timer reconnect_timer_;


### PR DESCRIPTION
```
commit fed1a401607ed31781d0668be540ecc3e9356f78
Author: Megh Bhatt <meghb@juniper.net>
Date:   Sun Dec 22 22:41:56 2013 -0800

    Pass in shared_ptr for redisBoostClient in boost async_read_some
    so that the redisBoostClient object does not get deleted when
    the callback is still pending.
```
