### PR TITLE
This bug deals with providing backend table to record messagetypes arriv...

### DIFF
--- a/src/analytics/viz.sandesh
+++ b/src/analytics/viz.sandesh
@@ -303,6 +303,22 @@ const list<stat_table> _STAT_TABLES  = [
         ]
     },
     {
+      'stat_type' : 'FieldNames'
+      'stat_attr' : 'fields'
+      'obj_table' : 'NONE',
+      'attributes': [
+          { 'name' : 'fields.value',  'datatype' : 'string',    'index' : false},
+        ]
+    },
+    {
+      'stat_type' : 'FieldNames'
+      'stat_attr' : 'fieldi'
+      'obj_table' : 'NONE',
+      'attributes': [
+          { 'name' : 'fieldi.value',  'datatype' : 'int',    'index' : false},
+        ]
+    },
+    {
       'stat_type' : 'QueryPerfInfo',
       'stat_attr' : 'query_stats',
       'obj_table' : COLLECTOR_INFO_TABLE,

--- a/src/opserver/opserver.py
+++ b/src/opserver/opserver.py
@@ -1305,7 +1305,7 @@ class OpServer(object):
                 if (table == stat_table):
                     objtab = t.obj_table
                     break
-            if (objtab != None): 
+            if (objtab != None) and (objtab != "None"): 
             #import pdb; pdb.set_trace()
                 return list(self._uve_server.get_uve_list(objtab,
                         None, None, None, None, False))


### PR DESCRIPTION
...ing in log messages. We are using stats table infra to keep track of this.

The backend table used is StatsTableByStrStrTag. The stat name used is FieldNames.
When inserting into stat table the value of the name fields is recorded as messagetype
A new attribute fields.value is introduced. The value of this field stores the actual messagetype.
[Also uuid value is ff.. for each entry and we assign t2=0 for reasons discussed b4
]
