### PR TITLE
Analytics instance id support & all fields table removal

### DIFF
--- a/src/analytics/OpServerProxy.h
+++ b/src/analytics/OpServerProxy.h
@@ -33,23 +33,31 @@ public:
     virtual ~OpServerProxy();
 
     virtual bool UVEUpdate(const std::string &type, const std::string &attr,
-                           const std::string &source, const std::string &module,
+                           const std::string &source, const std::string &node_type,
+                           const std::string &module, 
+                           const std::string &instance_id,
                            const std::string &key, const std::string &message,
                            int32_t seq, const std::string& agg, 
                            const std::string& atyp, int64_t ts);
 
     // Use this to delete the object when the deleted attribute is set
     virtual bool UVEDelete(const std::string &type,
-                       const std::string &source, const std::string &module,
+                       const std::string &source, const std::string &node_type,
+                       const std::string &module, const std::string &instance_id,
                        const std::string &key, int32_t seq);
 
-    virtual bool GetSeq(const std::string &source, const std::string &module,
+    virtual bool GetSeq(const std::string &source, const std::string &node_type,
+        const std::string &module, const std::string &instance_id,
         std::map<std::string,int32_t> & seqReply);
 
-    virtual bool DeleteUVEs(const std::string &source, const std::string &module);
+    virtual bool DeleteUVEs(const std::string &source, const std::string &node_type,
+                            const std::string &module, 
+                            const std::string &instance_id);
 
-    bool RefreshGenerator(const std::string &source, const std::string &module);
-    bool WithdrawGenerator(const std::string &source, const std::string &module);
+    bool RefreshGenerator(const std::string &source, const std::string &node_type,
+        const std::string &module, const std::string &instance_id);
+    bool WithdrawGenerator(const std::string &source, const std::string &node_type,
+        const std::string &module, const std::string &instance_id);
     typedef boost::function<void(int)> GenCleanupReply;
     bool GeneratorCleanup(GenCleanupReply gcr);
     void FillRedisUVEMasterInfo(RedisUveMasterInfo& redis_uve_info);

--- a/src/analytics/analytics_cpuinfo.sandesh
+++ b/src/analytics/analytics_cpuinfo.sandesh
@@ -10,14 +10,14 @@ include "base/sandesh/cpuinfo.sandesh"
 
 struct  ModuleCpuInfo {
     1: string                              module_id
+    2: string                              instance_id
     4: cpuinfo.CpuLoadInfo                 cpu_info
 }
 
 struct AnalyticsCpuInfo {
-    1: string                              module_id
-    2: u16                                 inst_id
-    3: u32                                 mem_virt
-    4: double                              cpu_share
+    1: string                              module_instance_id
+    2: u32                                 mem_virt
+    3: double                              cpu_share
 }
 
 // This struct is part of the Collector UVE. (key is hostname of the Analytics Node)
@@ -38,6 +38,7 @@ struct  ModuleCpuState {
     10: optional u32                       queryengine_mem_virt (aggtype="stats", hbin="100000")
     11: optional u32                       opserver_mem_virt (aggtype="stats", hbin="100000")
 }
+
 uve sandesh ModuleCpuStateTrace {
     1: ModuleCpuState                   data
 }
@@ -45,8 +46,9 @@ uve sandesh ModuleCpuStateTrace {
 struct  AnalyticsCpuState {
     1: string                              name (key="ObjectCollectorInfo")
     2: optional bool                       deleted
-    3: optional list<AnalyticsCpuInfo>     cpu_info (tags=".module_id")
+    3: optional list<AnalyticsCpuInfo>     cpu_info (tags=".module_instance_id")
 }
+
 uve sandesh AnalyticsCpuStateTrace {
     1: AnalyticsCpuState data
 }

--- a/src/analytics/collector.h
+++ b/src/analytics/collector.h
@@ -10,6 +10,7 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/tuple/tuple_comparison.hpp>
 
 #include "base/parse_object.h"
 

--- a/src/analytics/collector_uve.sandesh
+++ b/src/analytics/collector_uve.sandesh
@@ -73,6 +73,8 @@ struct GeneratorSummaryInfo {
     1: string                              source
     2: string                              module_id    
     3: string                              state
+    4: string                              instance_id
+    5: string                              node_type    
 }
 
 struct CollectorStats {
@@ -122,6 +124,8 @@ trace sandesh publish_uve_update {
     4: string key
     5: string attr
     6: bool success
+    7: string node_type
+    8: string instance_id
 }
 
 trace sandesh publish_uve_delete {
@@ -131,6 +135,8 @@ trace sandesh publish_uve_delete {
     4: string key
     5: u32 seq
     6: bool success
+    7: string node_type
+    8: string instance_id
 }
 
 trace sandesh generator_getseq {

--- a/src/analytics/delrequest.lua
+++ b/src/analytics/delrequest.lua
@@ -20,13 +20,13 @@ local function sub_del(_values)
     end
 end
 
-local sm = ARGV[1]..":"..ARGV[2]
-redis.log(redis.LOG_NOTICE,"DelRequest for "..sm.." vizd "..ARGV[3].." timeout "..ARGV[4])
+local sm = ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4] 
+redis.log(redis.LOG_NOTICE,"DelRequest for "..sm.." vizd "..ARGV[5].." timeout "..ARGV[6])
 
 -- conditional delete :
 --     only delete if this generator is not owned by collector
-if ARGV[4] == "-1" then
-    local lttl = redis.call('exists', "GENERATOR:"..sm)
+if ARGV[6] == "-1" then
+    local lttl = redis.call('exists', "NGENERATOR:"..sm)
     if lttl == 1 then
         redis.log(redis.LOG_NOTICE,"DelRequest failed for "..sm)
         return false
@@ -73,19 +73,19 @@ for k,v in pairs(typ) do
     end
 end
 
-redis.call('del', "TYPES:"..ARGV[1]..":"..ARGV[2])
+redis.call('del', "TYPES:"..ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4])
 
 -- A collector is taking ownership of this generator
-if #ARGV[3] >= 1 then
-    redis.call('sadd', "GENERATORS", sm)
-    if ARGV[4] ~= "0" and ARGV[4] ~= "-1" then
-        redis.call('set', "GENERATOR:"..sm,ARGV[3],"EX",ARGV[4])
+if #ARGV[5] >= 1 then
+    redis.call('sadd', "NGENERATORS", sm)
+    if ARGV[6] ~= "0" and ARGV[6] ~= "-1" then
+        redis.call('set', "NGENERATOR:"..sm, ARGV[5], "EX", ARGV[6])
     else
-        redis.call('set', "GENERATOR:"..sm,ARGV[3])
+        redis.call('set', "NGENERATOR:"..sm, ARGV[5])
     end
 -- This generator is not owned by any collector
 else
-    redis.call('srem', "GENERATORS", sm)
-    redis.call('del', "GENERATOR:"..sm)
+    redis.call('srem', "NGENERATORS", sm)
+    redis.call('del', "NGENERATOR:"..sm)
 end
 return true

--- a/src/analytics/expiredgens.lua
+++ b/src/analytics/expiredgens.lua
@@ -3,16 +3,18 @@
 --
 
 redis.log(redis.LOG_NOTICE,"Expired Gens ")
-local gens = redis.call('smembers',"GENERATORS")
+local gens = redis.call('smembers',"NGENERATORS")
 local res = {}
 for k,v in pairs(gens) do
-	local lgen = redis.call('exists', "GENERATOR:"..v)
+	local lgen = redis.call('exists', "NGENERATOR:"..v)
 	local sep = ":"
-	local src = v:match(("([^"..sep.."]*)"..sep))
-	local mod = v:match((sep.."([^"..sep.."]*)"))
+        local vsep = v..sep
+	local src, node, mod, inst = vsep:match(("([^"..sep.."]*)"..sep):rep(4))
 	if lgen == 0 then
 		table.insert(res, src)
-		table.insert(res, mod)
+		table.insert(res, node)
+                table.insert(res, mod)
+                table.insert(res, inst)
 	end
 	redis.log(redis.LOG_NOTICE,"val for "..v.." is "..lgen)
 end

--- a/src/analytics/generator.h
+++ b/src/analytics/generator.h
@@ -7,6 +7,7 @@
 
 #include <boost/shared_ptr.hpp>
 #include <string>
+#include <boost/tuple/tuple.hpp>
 #include "viz_message.h"
 #include "base/queue_task.h"
 
@@ -40,11 +41,13 @@ struct RedisReplyMsg : public ssm::Message {
 
 class Generator {
 public:
-    typedef std::pair<std::string /* Source */, std::string /* Module */> GeneratorId;
+    typedef boost::tuple<std::string /* Source */, std::string /* Module */,
+        std::string /* Instance id */, std::string /* Node type */> GeneratorId;
 
     Generator(Collector * const collector, VizSession *session,
             SandeshStateMachine *state_machine,
-            const std::string &source, const std::string &module);
+            const std::string &source, const std::string &module,
+            const std::string &instance_id, const std::string &node_type);
     ~Generator();
 
     void ReceiveSandeshCtrlMsg(uint32_t connects);
@@ -62,6 +65,8 @@ public:
 
     const std::string &module() const { return module_; }
     const std::string &source() const { return source_; }
+    const std::string &instance_id() const { return instance_id_; }
+    const std::string &node_type() const { return node_type_; }
     VizSession * session() const { return viz_session_; }
     const std::string ToString() const { return name_; }
     SandeshStateMachine * get_state_machine(void) {
@@ -122,6 +127,8 @@ private:
 
     const std::string source_;
     const std::string module_;
+    const std::string instance_id_;
+    const std::string node_type_;
     const std::string name_;
 
     boost::scoped_ptr<DbHandler> db_handler_;

--- a/src/analytics/redis_processor_vizd.h
+++ b/src/analytics/redis_processor_vizd.h
@@ -20,7 +20,8 @@ public:
     static bool
     UVEUpdate(RedisAsyncConnection * rac, RedisProcessorIf *rpi,
                        const std::string &type, const std::string &attr,
-                       const std::string &source, const std::string &module,
+                       const std::string &source, const std::string &node_type,
+                       const std::string &module, const std::string &instance_id,
                        const std::string &key, const std::string &message,
                        int32_t seq, const std::string &agg,
                        const std::string &atyp, int64_t ts);
@@ -28,29 +29,34 @@ public:
     static bool
     UVEDelete(RedisAsyncConnection * rac, RedisProcessorIf *rpi,
             const std::string &type,
-            const std::string &source, const std::string &module,
+            const std::string &source, const std::string &node_type,
+            const std::string &module, const std::string &instance_id,
             const std::string &key, int32_t seq);
 
     static bool
     SyncGetSeq(const std::string & redis_ip, unsigned short redis_port,  
-            const std::string &source, const std::string &module,
+            const std::string &source, const std::string &node_type,
+            const std::string &module, const std::string &instance_id,
             const std::string & coll,  int timeout,
             std::map<std::string,int32_t> & seqReply);
 
     static bool 
     SyncDeleteUVEs(const std::string & redis_ip, unsigned short redis_port,  
-            const std::string &source, const std::string &module,
+            const std::string &source, const std::string &node_type,
+            const std::string &module, const std::string &instance_id,
             const std::string & coll,  int timeout);
 
     static void
     RefreshGenerator(RedisAsyncConnection * rac,
-            const std::string &source, const std::string &module,
+            const std::string &source, const std::string &node_type,
+            const std::string &module, const std::string &instance_id,
             const std::string &coll, int timeout);
 
   
     static void
     WithdrawGenerator(RedisAsyncConnection * rac,
-            const std::string &source, const std::string &module,
+            const std::string &source, const std::string &node_type,
+            const std::string &module, const std::string &instance_id,
             const std::string &coll);
            
 };

--- a/src/analytics/seqnum.lua
+++ b/src/analytics/seqnum.lua
@@ -2,11 +2,11 @@
 -- Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
 --
 
-redis.log(redis.LOG_NOTICE,"GetSeq for "..ARGV[1]..":"..ARGV[2].." Vizd "..ARGV[3])
-local typ = redis.call('smembers',"TYPES:"..ARGV[1]..":"..ARGV[2])
+redis.log(redis.LOG_NOTICE,"GetSeq for "..ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4].." Vizd "..ARGV[5])
+local typ = redis.call('smembers',"TYPES:"..ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4])
 local res = {}
 for k,v in pairs(typ) do
-    local lres = redis.call('zrange',"UVES:"..ARGV[1]..":"..ARGV[2]..":"..v, -1, -1, "withscores")
+    local lres = redis.call('zrange',"UVES:"..ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4]..":"..v, -1, -1, "withscores")
     if #lres == 2 then 
 	    table.insert(res,v)
 	    table.insert(res,lres[2])
@@ -14,10 +14,10 @@ for k,v in pairs(typ) do
 		redis.log(redis.LOG_NOTICE,"GetSeq no seq for "..v)
 	end
 end
-redis.call('sadd', "GENERATORS", ARGV[1]..":"..ARGV[2])
-if ARGV[4] ~= "0" then
-    redis.call('set', "GENERATOR:"..ARGV[1]..":"..ARGV[2],ARGV[3],"EX",ARGV[4])
+redis.call('sadd', "NGENERATORS", ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4])
+if ARGV[6] ~= "0" then
+    redis.call('set', "NGENERATOR:"..ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4], ARGV[5], "EX", ARGV[6])
 else
-    redis.call('set', "GENERATOR:"..ARGV[1]..":"..ARGV[2],ARGV[3])
+    redis.call('set', "NGENERATOR:"..ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4], ARGV[5])
 end
 return res

--- a/src/analytics/test/viz_collector_test.cc
+++ b/src/analytics/test/viz_collector_test.cc
@@ -46,7 +46,7 @@ public:
     virtual void SetUp() {
         evm_.reset(new EventManager());
         thread_.reset(new ServerThread(evm_.get()));
-        Sandesh::InitGenerator("VizdTest", sourcehost, evm_.get(),
+        Sandesh::InitGenerator("VizdTest", sourcehost, "Test", "Test", evm_.get(),
                                8080, NULL);
         Sandesh::ConnectToCollector(collector_server, collector_port);
     }

--- a/src/analytics/test/viz_flow_test.cc
+++ b/src/analytics/test/viz_flow_test.cc
@@ -45,7 +45,7 @@ public:
     virtual void SetUp() {
         evm_.reset(new EventManager());
         thread_.reset(new ServerThread(evm_.get()));
-        Sandesh::InitGenerator("VizdTest", "127.0.0.1", evm_.get(),
+        Sandesh::InitGenerator("VizdTest", "127.0.0.1", "Test", "Test", evm_.get(),
                                0, NULL);
         Sandesh::ConnectToCollector(collector_server, collector_port);
     }

--- a/src/analytics/test/vizd_test.cc
+++ b/src/analytics/test/vizd_test.cc
@@ -56,7 +56,7 @@ public:
     GeneratorTest() : 
         evm_(new EventManager()),
         thread_(new ServerThread(evm_.get())) {
-        Sandesh::InitGenerator("GeneratorTest", sourcehost, evm_.get(),
+        Sandesh::InitGenerator("GeneratorTest", sourcehost, "Test", "Test", evm_.get(),
                 collector_server, collector_port, 0, NULL, true);
 
         thread_->Start();

--- a/src/analytics/uvedelete.lua
+++ b/src/analytics/uvedelete.lua
@@ -20,9 +20,9 @@ local function sub_del(_values)
     end
 end
 
-local sm = ARGV[1]..":"..ARGV[2]
-local typ = ARGV[3]
-local key = ARGV[4]
+local sm = ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4]
+local typ = ARGV[5]
+local key = ARGV[6]
 
 local _del = KEYS[1]
 local _values = KEYS[2]

--- a/src/analytics/uveupdate.lua
+++ b/src/analytics/uveupdate.lua
@@ -2,12 +2,12 @@
 -- Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
 --
 
-local sm = ARGV[1]..":"..ARGV[2]
-local typ = ARGV[3]
-local attr = ARGV[4]
-local key = ARGV[5]
-local seq = ARGV[6]
-local val = ARGV[7]
+local sm = ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4]
+local typ = ARGV[5]
+local attr = ARGV[6]
+local key = ARGV[7]
+local seq = ARGV[8]
+local val = ARGV[9]
 
 local _types = KEYS[1]
 local _origins = KEYS[2]

--- a/src/analytics/uveupdate_st.lua
+++ b/src/analytics/uveupdate_st.lua
@@ -27,14 +27,14 @@ local function histbin(hist,hval)
 end
 
 
-local sm = ARGV[1]..":"..ARGV[2]
-local typ = ARGV[3]
-local attr = ARGV[4]
-local key = ARGV[5]
-local seq = ARGV[6]
-local hist = tonumber(ARGV[7])
-local tim = ARGV[8]
-local val = tonumber(ARGV[9])
+local sm = ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4]
+local typ = ARGV[5]
+local attr = ARGV[6]
+local key = ARGV[7]
+local seq = ARGV[8]
+local hist = tonumber(ARGV[9])
+local tim = ARGV[10]
+local val = tonumber(ARGV[11])
 
 local _types = KEYS[1]
 local _origins = KEYS[2]

--- a/src/analytics/viz.sandesh
+++ b/src/analytics/viz.sandesh
@@ -14,6 +14,8 @@ const string UUID_KEY               = "UuidKey"
 const string SOURCE                 = "Source"
 const string NAMESPACE              = "Namespace"
 const string MODULE                 = "ModuleId"
+const string INSTANCE_ID            = "InstanceId"
+const string NODE_TYPE              = "NodeType"
 const string TIMESTAMP              = "MessageTS"
 const string SANDESH_TYPE           = "Type"
 const string CATEGORY               = "Category"
@@ -165,7 +167,7 @@ const map<FlowRecordFields, string> FlowRecordNames = {
 
 /* REDIS RELATED NAMES/CONSTANTS */
 
-const string GENERATORS_SET         = "GENERATORS"
+const string GENERATORS_SET         = "NGENERATORS"
 const string ANALYTICS_START        = "ANALYTICS_START_TIME"
 
 // each row will have equivalent of 2^23 = 8388608 usec
@@ -350,6 +352,8 @@ const list<query_table> _TABLES = [
                { 'name' : 'Category', 'datatype' : 'string', 'index' : true },
                { 'name' : 'Level', 'datatype' : 'int', 'index' : true },
                { 'name' : 'Type', 'datatype' : 'int', 'index' : false },
+               { 'name' : 'InstanceId', 'datatype' : 'string', 'index' : false },
+               { 'name' : 'NodeType', 'datatype' : 'string', 'index' : false },
                { 'name' : 'Messagetype', 'datatype' : 'string', 'index' : true },
                { 'name' : 'SequenceNum', 'datatype' : 'int', 'index' : false },
                { 'name' : 'Context', 'datatype' : 'string', 'index' : false },

--- a/src/analytics/vizd_table_desc.cc
+++ b/src/analytics/vizd_table_desc.cc
@@ -33,6 +33,10 @@ void init_vizd_tables() {
                        GenDb::DbDataType::AsciiType)
                       (g_viz_constants.MODULE,
                        GenDb::DbDataType::AsciiType)
+                      (g_viz_constants.INSTANCE_ID,
+                       GenDb::DbDataType::AsciiType)
+                      (g_viz_constants.NODE_TYPE,
+                       GenDb::DbDataType::AsciiType)
                       (g_viz_constants.CONTEXT,
                        GenDb::DbDataType::AsciiType)
                       (g_viz_constants.TIMESTAMP,
@@ -190,77 +194,132 @@ void init_vizd_tables() {
         (GenDb::NewCf(g_viz_constants.FLOW_TABLE_SVN_SIP,
                       boost::assign::list_of
                       (GenDb::DbDataType::Unsigned32Type)
+                      (GenDb::DbDataType::Unsigned8Type)
                       (GenDb::DbDataType::Unsigned8Type),
                       boost::assign::list_of
                       (GenDb::DbDataType::AsciiType)
                       (GenDb::DbDataType::Unsigned32Type)
-                      (GenDb::DbDataType::Unsigned32Type),
+                      (GenDb::DbDataType::Unsigned32Type)
+                      (GenDb::DbDataType::LexicalUUIDType),
                       boost::assign::list_of
                       (GenDb::DbDataType::Unsigned64Type)
                       (GenDb::DbDataType::Unsigned64Type)
                       (GenDb::DbDataType::Unsigned8Type)
                       (GenDb::DbDataType::LexicalUUIDType)
+                      (GenDb::DbDataType::AsciiType)
+                      (GenDb::DbDataType::AsciiType)
+                      (GenDb::DbDataType::AsciiType)
+                      (GenDb::DbDataType::Unsigned32Type)
+                      (GenDb::DbDataType::Unsigned32Type)
+                      (GenDb::DbDataType::Unsigned8Type)
+                      (GenDb::DbDataType::Unsigned16Type)
+                      (GenDb::DbDataType::Unsigned16Type)
+                      (GenDb::DbDataType::AsciiType)
                      ))
 
     /* (DVN,DIP) index table */
     (GenDb::NewCf(g_viz_constants.FLOW_TABLE_DVN_DIP,
                   boost::assign::list_of
                   (GenDb::DbDataType::Unsigned32Type)
+                  (GenDb::DbDataType::Unsigned8Type)
                   (GenDb::DbDataType::Unsigned8Type),
                   boost::assign::list_of
                   (GenDb::DbDataType::AsciiType)
                   (GenDb::DbDataType::Unsigned32Type)
-                  (GenDb::DbDataType::Unsigned32Type),
+                  (GenDb::DbDataType::Unsigned32Type)
+                  (GenDb::DbDataType::LexicalUUIDType),
                   boost::assign::list_of
                   (GenDb::DbDataType::Unsigned64Type)
                   (GenDb::DbDataType::Unsigned64Type)
                   (GenDb::DbDataType::Unsigned8Type)
                   (GenDb::DbDataType::LexicalUUIDType)
+                  (GenDb::DbDataType::AsciiType)
+                  (GenDb::DbDataType::AsciiType)
+                  (GenDb::DbDataType::AsciiType)
+                  (GenDb::DbDataType::Unsigned32Type)
+                  (GenDb::DbDataType::Unsigned32Type)
+                  (GenDb::DbDataType::Unsigned8Type)
+                  (GenDb::DbDataType::Unsigned16Type)
+                  (GenDb::DbDataType::Unsigned16Type)
+                  (GenDb::DbDataType::AsciiType)
                  ))
 
  /* (PROT, SP) index table */
         (GenDb::NewCf(g_viz_constants.FLOW_TABLE_PROT_SP,
                 boost::assign::list_of
                 (GenDb::DbDataType::Unsigned32Type)
+                (GenDb::DbDataType::Unsigned8Type)
                 (GenDb::DbDataType::Unsigned8Type),
                 boost::assign::list_of
                 (GenDb::DbDataType::Unsigned8Type)
                 (GenDb::DbDataType::Unsigned16Type)
-                (GenDb::DbDataType::Unsigned32Type),
+                (GenDb::DbDataType::Unsigned32Type)
+                (GenDb::DbDataType::LexicalUUIDType),
                 boost::assign::list_of
                 (GenDb::DbDataType::Unsigned64Type)
                 (GenDb::DbDataType::Unsigned64Type)
                 (GenDb::DbDataType::Unsigned8Type)
                 (GenDb::DbDataType::LexicalUUIDType)
+                (GenDb::DbDataType::AsciiType)
+                (GenDb::DbDataType::AsciiType)
+                (GenDb::DbDataType::AsciiType)
+                (GenDb::DbDataType::Unsigned32Type)
+                (GenDb::DbDataType::Unsigned32Type)
+                (GenDb::DbDataType::Unsigned8Type)
+                (GenDb::DbDataType::Unsigned16Type)
+                (GenDb::DbDataType::Unsigned16Type)
+                (GenDb::DbDataType::AsciiType)
                 ))
         /* (PROT, DP) index table */
         (GenDb::NewCf(g_viz_constants.FLOW_TABLE_PROT_DP,
                       boost::assign::list_of
                       (GenDb::DbDataType::Unsigned32Type)
+                      (GenDb::DbDataType::Unsigned8Type)
                       (GenDb::DbDataType::Unsigned8Type),
                       boost::assign::list_of
                       (GenDb::DbDataType::Unsigned8Type)
                       (GenDb::DbDataType::Unsigned16Type)
-                      (GenDb::DbDataType::Unsigned32Type),
+                      (GenDb::DbDataType::Unsigned32Type)
+                      (GenDb::DbDataType::LexicalUUIDType),
                       boost::assign::list_of
                       (GenDb::DbDataType::Unsigned64Type)
                       (GenDb::DbDataType::Unsigned64Type)
                       (GenDb::DbDataType::Unsigned8Type)
                       (GenDb::DbDataType::LexicalUUIDType)
+                      (GenDb::DbDataType::AsciiType)
+                      (GenDb::DbDataType::AsciiType)
+                      (GenDb::DbDataType::AsciiType)
+                      (GenDb::DbDataType::Unsigned32Type)
+                      (GenDb::DbDataType::Unsigned32Type)
+                      (GenDb::DbDataType::Unsigned8Type)
+                      (GenDb::DbDataType::Unsigned16Type)
+                      (GenDb::DbDataType::Unsigned16Type)
+                      (GenDb::DbDataType::AsciiType)
                      ))
  /* (VROUTER) index table */
         (GenDb::NewCf(g_viz_constants.FLOW_TABLE_VROUTER,
                       boost::assign::list_of
                       (GenDb::DbDataType::Unsigned32Type)
+                      (GenDb::DbDataType::Unsigned8Type)
                       (GenDb::DbDataType::Unsigned8Type),
                       boost::assign::list_of
                       (GenDb::DbDataType::AsciiType)
-                      (GenDb::DbDataType::Unsigned32Type),
+                      (GenDb::DbDataType::Unsigned32Type)
+                      (GenDb::DbDataType::LexicalUUIDType),
                       boost::assign::list_of
                       (GenDb::DbDataType::Unsigned64Type)
                       (GenDb::DbDataType::Unsigned64Type)
                       (GenDb::DbDataType::Unsigned8Type)
                       (GenDb::DbDataType::LexicalUUIDType)
+                      (GenDb::DbDataType::AsciiType)
+                      (GenDb::DbDataType::AsciiType)
+                      (GenDb::DbDataType::AsciiType)
+                      (GenDb::DbDataType::Unsigned32Type)
+                      (GenDb::DbDataType::Unsigned32Type)
+                      (GenDb::DbDataType::Unsigned8Type)
+                      (GenDb::DbDataType::Unsigned16Type)
+                      (GenDb::DbDataType::Unsigned16Type)
+                      (GenDb::DbDataType::AsciiType)
                      ))
 /* Stats Table by String,Str tag
  * The schema is as follows:

--- a/src/analytics/withdrawgen.lua
+++ b/src/analytics/withdrawgen.lua
@@ -2,11 +2,11 @@
 -- Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
 --
 
-local coll = redis.call('get',"GENERATOR:"..ARGV[1]..":"..ARGV[2])
+local coll = redis.call('get',"NGENERATOR:"..ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4])
 
-if coll == ARGV[3] then
-	redis.log(redis.LOG_NOTICE,"Withdraw Gen "..ARGV[1]..":"..ARGV[2].." Collector "..ARGV[3])
-	redis.call('del', "GENERATOR:"..ARGV[1]..":"..ARGV[2])
+if coll == ARGV[5] then
+	redis.log(redis.LOG_NOTICE,"Withdraw Gen "..ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4].." Collector "..ARGV[5])
+	redis.call('del', "NGENERATOR:"..ARGV[1]..":"..ARGV[2]..":"..ARGV[3]..":"..ARGV[4])
 	return true
 end
 

--- a/src/bgp/test/bgp_stress_test.cc
+++ b/src/bgp/test/bgp_stress_test.cc
@@ -513,7 +513,8 @@ void BgpStressTest::SetUp() {
 
         boost::system::error_code error;
         string hostname(boost::asio::ip::host_name(error));
-        Sandesh::InitGenerator("BgpUnitTestSandeshClient", hostname, &evm_,
+        Sandesh::InitGenerator("BgpUnitTestSandeshClient", hostname, 
+                               "BgpTest", "Test", &evm_,
                                 d_http_port_, sandesh_context_.get());
         Sandesh::ConnectToCollector("127.0.0.1",
                                     sandesh_server_->GetPort());

--- a/src/config/api-server/vnc_cfg_api_server.py
+++ b/src/config/api-server/vnc_cfg_api_server.py
@@ -50,8 +50,8 @@ from cfgm_common.uve.virtual_machine.ttypes import VMLog
 from cfgm_common.uve.virtual_network.ttypes import UveVirtualNetworkConfig,\
     UveVirtualNetworkConfigTrace, VnPolicy, VNLog
 from cfgm_common.uve.vrouter.ttypes import VRLog
-from sandesh_common.vns.ttypes import Module
-from sandesh_common.vns.constants import ModuleNames
+from sandesh_common.vns.ttypes import Module, NodeType
+from sandesh_common.vns.constants import ModuleNames, Module2NodeType, NodeTypeNames, INSTANCE_ID_DEFAULT
 from provision_defaults import Provision
 from gen.resource_xsd import *
 from gen.resource_common import *
@@ -240,17 +240,17 @@ class VncApiServer(VncApiServerGen):
 
         # sandesh init
         self._sandesh = Sandesh()
+        module = Module.API_SERVER
+        module_name = ModuleNames[Module.API_SERVER]
+        node_type = Module2NodeType[module]
+        node_type_name = NodeTypeNames[node_type]
         if self._args.worker_id:
-            # HACK till rest of infra catches up, worker 0 doesn't
-            # encode in name
-            if self._args.worker_id == '0':
-                module = ModuleNames[Module.API_SERVER]
-            else:
-                module = ModuleNames[Module.API_SERVER] + self._args.worker_id
+            instance_id = self._args.worker_id
         else:
-            module = ModuleNames[Module.API_SERVER]
-        self._sandesh.init_generator(module, socket.gethostname(),
-                                     self._args.collectors,
+            instance_id = INSTANCE_ID_DEFAULT
+        self._sandesh.init_generator(module_name, socket.gethostname(),
+                                     node_type_name, instance_id,
+                                     self._args.collectors, 
                                      'vnc_api_server_context',
                                      int(self._args.http_server_port),
                                      ['cfgm_common', 'sandesh'], self._disc)
@@ -315,7 +315,8 @@ class VncApiServer(VncApiServerGen):
         sysinfo_req = True
         config_node_ip = self.get_server_ip()
         cpu_info = vnc_cpu_info.CpuInfo(
-            Module.API_SERVER, sysinfo_req, self._sandesh, 60, config_node_ip)
+            self._sandesh.module(), self._sandesh.instance_id(), sysinfo_req, 
+            self._sandesh, 60, config_node_ip)
         self._cpu_info = cpu_info
 
     # end __init__

--- a/src/config/common/vnc_cpu_info.py
+++ b/src/config/common/vnc_cpu_info.py
@@ -13,18 +13,16 @@ from uve.cfgm_cpuinfo.ttypes import *
 from uve.cfgm_cpuinfo.cpuinfo.ttypes import *
 from buildinfo import build_info
 
-from sandesh_common.vns.ttypes import Module
-from sandesh_common.vns.constants import ModuleNames
-
 # CpuInfo object for config-node
 
 
 class CpuInfo(object):
 
-    def __init__(self, module_num, sysinfo_req, sandesh,
+    def __init__(self, module_id, instance_id, sysinfo_req, sandesh,
                  time_interval, server_ip=None):
         # store cpuinfo at init
-        self._module_id = ModuleNames[module_num]
+        self._module_id = module_id
+        self._instance_id = instance_id 
         self._sysinfo = sysinfo_req
         self._sandesh = sandesh
         self._time_interval = time_interval
@@ -132,6 +130,7 @@ class CpuInfo(object):
     def _send_cpustats(self):
         mod_cpu = ModuleCpuInfo()
         mod_cpu.module_id = self._module_id
+        mod_cpu.instance_id = self._instance_id
 
         mod_cpu.cpu_info = CpuLoadInfo()
 

--- a/src/config/schema-transformer/to_bgp.py
+++ b/src/config/schema-transformer/to_bgp.py
@@ -38,8 +38,8 @@ from vnc_api.vnc_api import *
 from pysandesh.sandesh_base import *
 from pysandesh.gen_py.sandesh.ttypes import SandeshLevel
 from cfgm_common.uve.virtual_network.ttypes import *
-from sandesh_common.vns.ttypes import Module
-from sandesh_common.vns.constants import ModuleNames
+from sandesh_common.vns.ttypes import Module, NodeType
+from sandesh_common.vns.constants import ModuleNames, Module2NodeType, NodeTypeNames, INSTANCE_ID_DEFAULT
 from schema_transformer.sandesh.st_introspect import ttypes as sandesh
 from ncclient import manager
 import discovery.client as client
@@ -2134,8 +2134,13 @@ class SchemaTransformer(object):
         sandesh.VnList.handle_request = self.sandesh_vn_handle_request
         sandesh.RoutintInstanceList.handle_request =\
             self.sandesh_ri_handle_request
+        module = Module.SCHEMA_TRANSFORMER
+        module_name = ModuleNames[module]
+        node_type = Module2NodeType[module]
+        node_type_name = NodeTypeNames[node_type]
+        instance_id = INSTANCE_ID_DEFAULT
         _sandesh.init_generator(
-            ModuleNames[Module.SCHEMA_TRANSFORMER], socket.gethostname(),
+            module_name, socket.gethostname(), node_type_name, instance_id,
             self._args.collectors, 'to_bgp_context', int(args.http_server_port),
             ['cfgm_common', 'schema_transformer.sandesh'], self._disc)
         _sandesh.set_logging_params(enable_local_log=args.log_local,
@@ -2146,7 +2151,7 @@ class SchemaTransformer(object):
         # create cpu_info object to send periodic updates
         sysinfo_req = False
         cpu_info = vnc_cpu_info.CpuInfo(
-            Module.SCHEMA_TRANSFORMER, sysinfo_req, _sandesh, 60)
+            module_name, instance_id, sysinfo_req, _sandesh, 60)
         self._cpu_info = cpu_info
 
     # end __init__

--- a/src/config/svc-monitor/svc_monitor.py
+++ b/src/config/svc-monitor/svc_monitor.py
@@ -35,8 +35,8 @@ from vnc_api.vnc_api import *
 from pysandesh.sandesh_base import Sandesh
 from pysandesh.gen_py.sandesh.ttypes import SandeshLevel
 from cfgm_common.uve.service_instance.ttypes import *
-from sandesh_common.vns.ttypes import Module
-from sandesh_common.vns.constants import ModuleNames
+from sandesh_common.vns.ttypes import Module, NodeType
+from sandesh_common.vns.constants import ModuleNames, Module2NodeType, NodeTypeNames, INSTANCE_ID_DEFAULT
 from sandesh.svc_mon_introspect import ttypes as sandesh
 
 # nova imports
@@ -92,8 +92,13 @@ class SvcMonitor(object):
         self._sandesh = Sandesh()
         sandesh.ServiceInstanceList.handle_request =\
             self.sandesh_si_handle_request
+        module = Module.SVC_MONITOR
+        module_name = ModuleNames[module]
+        node_type = Module2NodeType[module]
+        node_type_name = NodeTypeNames[node_type]
+        instance_id = INSTANCE_ID_DEFAULT
         self._sandesh.init_generator(
-            ModuleNames[Module.SVC_MONITOR], socket.gethostname(),
+            module_name, socket.gethostname(), node_type_name, instance_id,
             self._args.collectors, 'svc_monitor_context',
             int(self._args.http_server_port), ['cfgm_common', 'sandesh'],
             self._disc)
@@ -111,7 +116,7 @@ class SvcMonitor(object):
         #create cpu_info object to send periodic updates
         sysinfo_req = False
         cpu_info = vnc_cpu_info.CpuInfo(
-            Module.SVC_MONITOR, sysinfo_req, self._sandesh, 60)
+            module_name, instance_id, sysinfo_req, self._sandesh, 60)
         self._cpu_info = cpu_info
 
         # logging

--- a/src/config/uve/cfgm_cpuinfo.sandesh
+++ b/src/config/uve/cfgm_cpuinfo.sandesh
@@ -9,6 +9,7 @@ include "base/sandesh/cpuinfo.sandesh"
 struct  ModuleCpuInfo {
     1: string module_id
     2: cpuinfo.CpuLoadInfo cpu_info
+    3: string instance_id
 }
 
 // This struct is part of the Config None UVE. 

--- a/src/control-node/main.cc
+++ b/src/control-node/main.cc
@@ -489,10 +489,16 @@ int main(int argc, char *argv[]) {
     ControlNode::SetDefaultSchedulingPolicy();
     BgpSandeshContext sandesh_context;
 
-    if (!var_map.count("discovery-server")) { 
+    if (!var_map.count("discovery-server")) {
+        Module::type module = Module::CONTROL_NODE;
+        NodeType::type node_type = 
+            g_vns_constants.Module2NodeType.find(module)->second; 
         Sandesh::InitGenerator(
-            g_vns_constants.ModuleNames.find(Module::CONTROL_NODE)->second,
-            hostname, &evm,
+            g_vns_constants.ModuleNames.find(module)->second,
+            hostname, 
+            g_vns_constants.NodeTypeNames.find(node_type)->second,
+            g_vns_constants.INSTANCE_ID_DEFAULT, 
+            &evm,
             var_map["http-server-port"].as<int>(), &sandesh_context);
     }
 
@@ -587,14 +593,23 @@ int main(int argc, char *argv[]) {
 
         //subscribe to collector service if not configured
         if (!var_map.count("collector")) {
-           
+            Module::type module = Module::CONTROL_NODE;
+            NodeType::type node_type = 
+                g_vns_constants.Module2NodeType.find(module)->second;
+            string subscriber_name = 
+                g_vns_constants.ModuleNames.find(module)->second;
+            string node_type_name = 
+                g_vns_constants.NodeTypeNames.find(node_type)->second; 
             Sandesh::CollectorSubFn csf = 0;
             csf = boost::bind(&DiscoveryServiceClient::Subscribe,
                               ds_client, _1, _2, _3);
             vector<string> list;
             list.clear();
             Sandesh::InitGenerator(subscriber_name,
-                                   hostname, &evm,
+                                   hostname,
+                                   node_type_name,
+                                   g_vns_constants.INSTANCE_ID_DEFAULT, 
+                                   &evm,
                                    var_map["http-server-port"].as<int>(),
                                    csf,
                                    list,

--- a/src/discovery/disc_server_zk.py
+++ b/src/discovery/disc_server_zk.py
@@ -38,8 +38,9 @@ import output
 # sandesh
 from pysandesh.sandesh_base import *
 from pysandesh.gen_py.sandesh.ttypes import SandeshLevel
-from sandesh.vns.ttypes import Module
-from sandesh.vns.constants import ModuleNames
+from sandesh_common.vns.ttypes import Module, NodeType
+from sandesh_common.vns.constants import ModuleNames, Module2NodeType, NodeTypeNames,\
+    INSTANCE_ID_DEFAULT    
 from sandesh.discovery_introspect import ttypes as sandesh
 
 from gevent.coros import BoundedSemaphore
@@ -163,8 +164,13 @@ class DiscoveryServer():
 
         # sandesh init
         self._sandesh = Sandesh()
+        module = Module.DISCOVERY_SERVICE
+        module_name = ModuleNames[module]
+        node_type = Module2NodeType[module]
+        node_type_name = NodeTypeNames[node_type]
+        instance_id = self._args.worker_id
         self._sandesh.init_generator(
-            ModuleNames[Module.DISCOVERY_SERVICE], socket.gethostname(),
+            module_name, socket.gethostname(), node_type_name, instance_id,
             self._args.collectors, 'discovery_context', 
             int(self._args.http_server_port), ['sandesh', 'uve'])
         self._sandesh.set_logging_params(enable_local_log=self._args.log_local,
@@ -298,7 +304,8 @@ class DiscoveryServer():
             'log_local': False,
             'log_level': SandeshLevel.SYS_DEBUG,
             'log_category': '',
-            'log_file': Sandesh._DEFAULT_LOG_FILE
+            'log_file': Sandesh._DEFAULT_LOG_FILE,
+            'worker_id': INSTANCE_ID_DEFAULT,
         }
 
         # per service options

--- a/src/dns/main.cc
+++ b/src/dns/main.cc
@@ -157,9 +157,14 @@ int main(int argc, char *argv[]) {
     string hostname = host_name(ec);
     Dns::SetHostName(hostname);
     if (!var_map.count("discovery-server")) {
+        Module::type module = Module::DNS;
+        NodeType::type node_type = 
+            g_vns_constants.Module2NodeType.find(module)->second;
         Sandesh::InitGenerator(
-                    g_vns_constants.ModuleNames.find(Module::DNS)->second,
+                    g_vns_constants.ModuleNames.find(module)->second,
                     hostname,
+                    g_vns_constants.NodeTypeNames.find(node_type)->second,
+                    g_vns_constants.INSTANCE_ID_DEFAULT,
                     Dns::GetEventManager(),
                     sandesh_http_port, &sandesh_context);
     }
@@ -230,16 +235,22 @@ int main(int argc, char *argv[]) {
 
         //subscribe to collector service if not configured
         if (!var_map.count("collector")) {
+            Module::type module = Module::DNS;
+            NodeType::type node_type = 
+                g_vns_constants.Module2NodeType.find(module)->second;
             string subscriber_name = 
-                g_vns_constants.ModuleNames.find(Module::DNS)->second;
-
+                g_vns_constants.ModuleNames.find(module)->second;
+            string node_type_name =
+                g_vns_constants.NodeTypeNames.find(node_type)->second;
             Sandesh::CollectorSubFn csf = 0;
             csf = boost::bind(&DiscoveryServiceClient::Subscribe, ds_client,
                               _1, _2, _3);
             vector<string> list;
             list.clear();
             Sandesh::InitGenerator(subscriber_name,
-                                   hostname, Dns::GetEventManager(),
+                                   hostname, node_type_name,
+                                   g_vns_constants.INSTANCE_ID_DEFAULT,
+                                   Dns::GetEventManager(),
                                    sandesh_http_port,
                                    csf,
                                    list,

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -214,7 +214,7 @@ main(int argc, char *argv[]) {
     http.RegisterHandler("quitquitquit",
 	boost::bind(&ServerShutdown, &http, _1, _2));
     http.Initialize(8090);
-    Sandesh::InitGeneratorTest("httpd", boost::asio::ip::host_name(), &evm, 8080);
+    Sandesh::InitGeneratorTest("httpd", boost::asio::ip::host_name(), "httpd", "httpd", &evm, 8080);
     Sandesh::SetLoggingParams(true, "HttpSession", SandeshLevel::UT_INFO);
     evm.Run();
     http.Shutdown();

--- a/src/opserver/test/utils/generator_fixture.py
+++ b/src/opserver/test/utils/generator_fixture.py
@@ -49,7 +49,7 @@ class GeneratorFixture(fixtures.Fixture):
         self._sandesh_instance = Sandesh()
         self._http_port = AnalyticsFixture.get_free_port()
         self._sandesh_instance.init_generator(
-            self._name, socket.gethostname(), self._collectors,
+            self._name, socket.gethostname(), "Test", "0", self._collectors,
             '', self._http_port, sandesh_req_uve_pkg_list=['sandesh'])
         self._sandesh_instance.set_logging_params(enable_local_log=True,
                                                   level=SandeshLevel.UT_DEBUG)

--- a/src/opserver/uveserver.py
+++ b/src/opserver/uveserver.py
@@ -416,7 +416,7 @@ class UVEServer(object):
             redish = redis.StrictRedis(host=self._local_ip,
                                        port=self._local_port, db=0)
             for entry in redish.smembers("TABLE:" + key):
-                info = (entry.split(':', 1)[1]).rsplit(':', 3)
+                info = (entry.split(':', 1)[1]).rsplit(':', 5)
                 uve_key = info[0]
                 if kfilter is not None:
                     kfilter_match = False
@@ -430,18 +430,21 @@ class UVEServer(object):
                 if sfilter is not None:
                     if sfilter != src:
                         continue
-                mdule = info[2]
+                node_type = info[2]
+                mdule = info[3]
                 if mfilter is not None:
                     if mfilter != mdule:
                         continue
-                typ = info[3]
+                inst = info[4] 
+                typ = info[5]
                 if tfilter is not None:
                     if typ not in tfilter:
                         continue
                 if parse_afilter:
                     if tfilter is not None and len(tfilter[typ]):
                         valkey = "VALUES:" + key + ":" + uve_key + ":" + \
-                                 src + ":" + mdule + ":" + typ
+                                 src + ":" + node_type + ":" + mdule + \
+                                 ":" + inst + ":" + typ
                         for afilter in tfilter[typ]:
                             attrval = redish.hget(valkey, afilter)
                             if attrval is not None:

--- a/src/query_engine/db_query.cc
+++ b/src/query_engine/db_query.cc
@@ -33,8 +33,17 @@ query_status_t DbQueryUnit::process_query()
         if (t_only_row)
         {
             rowkey.push_back(t2);
+            if (m_query->is_flow_query()) {
+                uint8_t partition_no = 0;
+                rowkey.push_back(partition_no);
+            }
         } else {
             rowkey.push_back(t2);
+            if (m_query->is_flow_query()) {
+                uint8_t partition_no = 0;
+                rowkey.push_back(partition_no);
+            }
+
             for (GenDb::DbDataValueVec::iterator it = row_key_suffix.begin();
                     it!=row_key_suffix.end(); it++) {
                 rowkey.push_back(*it);
@@ -65,6 +74,15 @@ query_status_t DbQueryUnit::process_query()
                         assert(i->value.size()==1);                        
                         try {
                             t1 = boost::get<uint32_t>(i->name[2]);
+                        } catch (boost::bad_get& ex) {
+                            assert(0);
+                        }
+                    } else if (m_query->is_flow_query()) {
+                        int ts_at = i->name.size() - 2;
+                        assert(ts_at >= 0);
+                        
+                        try {
+                            t1 = boost::get<uint32_t>(i->name.at(ts_at));
                         } catch (boost::bad_get& ex) {
                             assert(0);
                         }

--- a/src/query_engine/query.cc
+++ b/src/query_engine/query.cc
@@ -758,13 +758,6 @@ void query_result_unit_t::get_uuid_stats_8tuple(boost::uuids::uuid& u,
     } catch (const std::out_of_range& oor) {
         QE_ASSERT(0);
     }
-    try {
-        tuple.direction = boost::get<uint8_t>(info.at(index++));
-    } catch (boost::bad_get& ex) {
-        QE_ASSERT(0);
-    } catch (const std::out_of_range& oor) {
-        QE_ASSERT(0);
-    }
     return;
 }
 

--- a/src/query_engine/select_fs_query.cc
+++ b/src/query_engine/select_fs_query.cc
@@ -247,6 +247,7 @@ query_status_t SelectQuery::process_fs_query(
         flow_stats stats;
         flow_tuple tuple;
         where_result_it->get_uuid_stats_8tuple(uuid, stats, tuple);
+        tuple.direction = mquery->wherequery_->direction_ing;
         uint64_t t = where_result_it->timestamp;
         // Check if the timestamp is interesting to us
         if (t < mquery->from_time || t > mquery->end_time) {

--- a/src/sandesh/common/vns.sandesh
+++ b/src/sandesh/common/vns.sandesh
@@ -21,6 +21,12 @@ enum Module {
     DISCOVERY_SERVICE,
     IFMAP_SERVER,
     XMPP_SERVER,
+    ANALYTICS_NODE_MGR,
+    CONTROL_NODE_MGR,
+    CONFIG_NODE_MGR,
+    DATABASE_NODE_MGR,
+    WEBUI_NODE_MGR,
+    COMPUTE_NODE_MGR,    
     MAX_MODULE,
 }
 
@@ -37,6 +43,12 @@ const map<Module, string> ModuleNames = {
     Module.DISCOVERY_SERVICE  : "DiscoveryService"
     Module.IFMAP_SERVER       : "IfmapServer",
     Module.XMPP_SERVER        : "XmppServer",
+    Module.ANALYTICS_NODE_MGR : "Contrail-Analytics-Nodemgr",
+    Module.CONTROL_NODE_MGR   : "Contrail-Control-Nodemgr",
+    Module.CONFIG_NODE_MGR    : "Contrail-Config-Nodemgr",
+    Module.DATABASE_NODE_MGR  : "Contrail-Database-Nodemgr",
+    Module.WEBUI_NODE_MGR     : "Contrail-WebUI-Nodemgr",
+    Module.COMPUTE_NODE_MGR   : "Contrail-Vrouter-Nodemgr",
 }
 
 const map<string, Module> ModuleIds = {
@@ -52,7 +64,58 @@ const map<string, Module> ModuleIds = {
     "DiscoveryService"      : Module.DISCOVERY_SERVICE
     "IfmapServer"           : Module.IFMAP_SERVER,
     "XmppServer"            : Module.XMPP_SERVER,
+    "Contrail-Analytics-Nodemgr" : Module.ANALYTICS_NODE_MGR,
+    "Contrail-Control-Nodemgr"   : Module.CONTROL_NODE_MGR,
+    "Contrail-Config-Nodemgr"    : Module.CONFIG_NODE_MGR,
+    "Contrail-Database-Nodemgr"  : Module.DATABASE_NODE_MGR,
+    "Contrail-WebUI-Nodemgr"     : Module.WEBUI_NODE_MGR,
+    "Contrail-Vrouter-Nodemgr"   : Module.COMPUTE_NODE_MGR,
 }
+
+enum NodeType {
+    INVALID,
+    CONFIG,
+    CONTROL,
+    ANALYTICS,
+    COMPUTE,
+    WEBUI,
+    DATABASE,
+    OPENSTACK,
+}
+
+const map<NodeType, string> NodeTypeNames = {
+    NodeType.INVALID         : "Invalid",
+    NodeType.CONFIG          : "Config",
+    NodeType.CONTROL         : "Control",
+    NodeType.ANALYTICS       : "Analytics",
+    NodeType.COMPUTE         : "Compute",
+    NodeType.WEBUI           : "WebUI",
+    NodeType.DATABASE        : "Database",
+    NodeType.OPENSTACK       : "OpenStack",
+}
+
+const map <Module, NodeType> Module2NodeType = {
+    Module.CONTROL_NODE       : NodeType.CONTROL,
+    Module.VROUTER_AGENT      : NodeType.COMPUTE,
+    Module.API_SERVER         : NodeType.CONFIG,
+    Module.SCHEMA_TRANSFORMER : NodeType.CONFIG,
+    Module.OPSERVER           : NodeType.ANALYTICS,
+    Module.COLLECTOR          : NodeType.ANALYTICS,
+    Module.QUERY_ENGINE       : NodeType.ANALYTICS,
+    Module.SVC_MONITOR        : NodeType.CONFIG,
+    Module.DNS                : NodeType.CONTROL,
+    Module.DISCOVERY_SERVICE  : NodeType.CONFIG,
+    Module.IFMAP_SERVER       : NodeType.CONFIG,
+    Module.XMPP_SERVER        : NodeType.CONTROL,
+    Module.ANALYTICS_NODE_MGR : NodeType.ANALYTICS,
+    Module.CONTROL_NODE_MGR   : NodeType.CONTROL,
+    Module.CONFIG_NODE_MGR    : NodeType.CONFIG,
+    Module.DATABASE_NODE_MGR  : NodeType.DATABASE,
+    Module.WEBUI_NODE_MGR     : NodeType.WEBUI,
+    Module.COMPUTE_NODE_MGR   : NodeType.COMPUTE,
+}
+
+const string INSTANCE_ID_DEFAULT = "0"
 
 enum Category {
     DEFAULT,

--- a/src/vnsw/agent/cfg/discovery_agent.cc
+++ b/src/vnsw/agent/cfg/discovery_agent.cc
@@ -94,8 +94,13 @@ void DiscoveryAgentClient::DiscoverServices() {
 
             //subscribe to collector service
             if (param_->collector().to_ulong() == 0) {
+                Module::type module = Module::VROUTER_AGENT;
+                NodeType::type node_type = 
+                    g_vns_constants.Module2NodeType.find(module)->second;
                 std::string subscriber_name = 
-                    g_vns_constants.ModuleNames.find(Module::VROUTER_AGENT)->second;
+                    g_vns_constants.ModuleNames.find(module)->second;
+                std::string node_type_name = 
+                    g_vns_constants.NodeTypeNames.find(node_type)->second;
 
                 Sandesh::CollectorSubFn csf = 0;
                 csf = boost::bind(&DiscoveryServiceClient::Subscribe, 
@@ -103,9 +108,11 @@ void DiscoveryAgentClient::DiscoverServices() {
                 std::vector<std::string> list;
                 list.clear();
                 Sandesh::InitGenerator(subscriber_name,
-                                       agent_cfg_->agent()->GetHostName(), 
-                                       agent_cfg_->agent()->GetEventManager(),
-                                       agent_cfg_->agent()->GetSandeshPort(),
+                                       Agent::GetInstance()->GetHostName(),
+                                       node_type_name,
+                                       g_vns_constants.INSTANCE_ID_DEFAULT, 
+                                       Agent::GetInstance()->GetEventManager(),
+                                       Agent::GetInstance()->GetSandeshPort(),
                                        csf,
                                        list,
                                        NULL);

--- a/src/vnsw/agent/cmn/agent.cc
+++ b/src/vnsw/agent/cmn/agent.cc
@@ -210,10 +210,16 @@ void Agent::CreateModules() {
                               params_->log_category(),
                               params_->log_level());
     if (dss_addr_.empty()) {
-        Sandesh::InitGenerator
-            (g_vns_constants.ModuleNames.find(Module::VROUTER_AGENT)->second,
-             params_->host_name(), GetEventManager(),
-             params_->http_server_port());
+        Module::type module = Module::VROUTER_AGENT;
+        NodeType::type node_type =
+            g_vns_constants.Module2NodeType.find(module)->second;
+        Sandesh::InitGenerator(
+            g_vns_constants.ModuleNames.find(module)->second,
+            params_->host_name(),
+            g_vns_constants.NodeTypeNames.find(node_type)->second,
+            g_vns_constants.INSTANCE_ID_DEFAULT,
+            GetEventManager(),
+            params_->http_server_port());
 
         if (params_->collector_port() != 0 && 
             !params_->collector().to_ulong() != 0) {

--- a/src/vnsw/agent/test/test_init.cc
+++ b/src/vnsw/agent/test/test_init.cc
@@ -51,7 +51,7 @@ TestClient *TestInit(const char *init_file, bool ksync_init, bool pkt_init,
 
     // Initialize the agent-init control class
     int sandesh_port = 0;
-    Sandesh::InitGeneratorTest("VNSWAgent", "Agent",
+    Sandesh::InitGeneratorTest("VNSWAgent", "Agent", "Test", "Test",
                                Agent::GetInstance()->GetEventManager(),
                                sandesh_port, NULL);
 
@@ -109,7 +109,7 @@ TestClient *StatsTestInit() {
 
     // Initialize the agent-init control class
     int sandesh_port = 0;
-    Sandesh::InitGeneratorTest("VNSWAgent", "Agent",
+    Sandesh::InitGeneratorTest("VNSWAgent", "Agent", "Test", "Test",
                                Agent::GetInstance()->GetEventManager(),
                                sandesh_port, NULL);
 
@@ -153,7 +153,7 @@ TestClient *VGwInit(const string &init_file, bool ksync_init) {
     param->Init(init_file, "test", var_map);
 
     // Initialize the agent-init control class
-    Sandesh::InitGeneratorTest("VNSWAgent", "Agent",
+    Sandesh::InitGeneratorTest("VNSWAgent", "Agent", "Test", "Test",
                                Agent::GetInstance()->GetEventManager(),
                                0, NULL);
 


### PR DESCRIPTION
1. Add instance id and node type support to generators and analytics to
   support multiple instances of process running on the same node
2. Remove all fields table
