### PR TITLE
Fix Buildinfo generation (bug 2252)

### DIFF
--- a/src/base/misc_utils.cc
+++ b/src/base/misc_utils.cc
@@ -13,12 +13,16 @@
 #include "boost/filesystem/path.hpp"
 #include "base/sandesh/version_types.h"
 #include "base/logging.h"
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
 
 using namespace std;
 namespace fs = boost::filesystem;
 const std::string MiscUtils::CoreFileDir = "/var/crashes/";
 const int MiscUtils::MaxCoreFiles = 5;
-const map<MiscUtils::BuildModule, string> MiscUtils::BuildModuleNames = MiscUtils::MapInit();
+const map<MiscUtils::BuildModule, string> MiscUtils::BuildModuleNames = 
+    MiscUtils::MapInit();
 
 SandeshTraceBufferPtr VersionTraceBuf(SandeshTraceBufferCreate(
                                        VERSION_TRACE_BUF, 500));
@@ -55,7 +59,8 @@ void MiscUtils::GetCoreFileList(string prog, vector<string> &list) {
             if (pos != 0) {
                 continue;
             }
-            files_map.insert(FileMMap::value_type(fs::last_write_time(itr->path()), file));
+            files_map.insert(FileMMap::value_type(fs::last_write_time
+                                                    (itr->path()), file));
         }
     }
     FileMMap::reverse_iterator rit;
@@ -64,33 +69,6 @@ void MiscUtils::GetCoreFileList(string prog, vector<string> &list) {
         count < MaxCoreFiles; ++rit) {
         count++;
         list.push_back(rit->second);
-    }
-}
-
-void MiscUtils::GetHostIp(const string hostname, vector<string> &ip_list) {
-    struct hostent *host;
-    host = gethostbyname(hostname.c_str());
-    if (host == NULL) {
-        return;
-    }
-    if (host->h_addrtype == AF_INET) {
-        char buff[INET_ADDRSTRLEN];
-        struct sockaddr_in addr;
-        int len = 0, i = 0;
-        string ip_addr;
-        while (len < host->h_length) {
-            addr.sin_addr = *(struct in_addr *)host->h_addr_list[i++];
-            addr.sin_family = host->h_addrtype;
-            inet_ntop(AF_INET, &(addr.sin_addr.s_addr), buff, sizeof(buff));
-            len += 4;
-            ip_addr = string(buff);
-            //ignore loop back addresses
-            int pos = ip_addr.find("127");
-            if (pos == 0) {
-                continue;
-            }
-            ip_list.push_back(ip_addr);
-        }
     }
 }
 
@@ -117,7 +95,8 @@ bool MiscUtils::GetVersionInfoInternal(const string &cmd, string &result) {
     return true;
 }
 
-bool MiscUtils::GetContrailVersionInfo(BuildModule id, string &rpm_version, string &build_num) {
+bool MiscUtils::GetContrailVersionInfo(BuildModule id, string &rpm_version, 
+                                       string &build_num) {
     bool ret1, ret2;
     stringstream build_id_cmd;
     build_id_cmd << "contrail-version | grep '" << BuildModuleNames.at(id);
@@ -135,12 +114,24 @@ bool MiscUtils::GetContrailVersionInfo(BuildModule id, string &rpm_version, stri
     return true;
 }
 
-bool MiscUtils::GetBuildInfo(BuildModule id, const string &build_info, string &result) {
+bool MiscUtils::GetBuildInfo(BuildModule id, const string &build_info, 
+                             string &result) {
     string rpm_version;
     string build_num;
 
     bool ret = GetContrailVersionInfo(id, rpm_version, build_num);
-    result = (build_info + "\"build-id\" : \"" + rpm_version + "\", \"build-number\" : \"" + build_num  + "\"}]}");
+    rapidjson::Document d;
+    d.Parse<0>(const_cast<char *>(build_info.c_str()));
+    rapidjson::Value& fields = d["build-info"];
+    fields[0u].AddMember("build-id", const_cast<char *>(rpm_version.c_str()), 
+                         d.GetAllocator());
+    fields[0u].AddMember("build-number", const_cast<char *>(build_num.c_str()), 
+                         d.GetAllocator());
+
+    rapidjson::StringBuffer strbuf;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(strbuf);
+    d.Accept(writer);
+    result = strbuf.GetString();
     return ret;
 }
 


### PR DESCRIPTION
In previous releases, json string for buildinfo was partially generated at compile time and rest of the json string (portion of info which can be obtained only during runtime) was appended at run-time(json parsing was not done). The partially generated json string was not a fully validjson string.

Now, the json string generated during compile time is a fully valid json string. The Run-time buildinfo is added to this json string by parsing the compile-time generated buildinfo. (Added json parser to parse buildinfo and add additional key-value pairs)

Also removed unused API from misc_utils.cc
