### PR TITLE
Verify ip string to be a valid ip address before publishing

### DIFF
--- a/src/control-node/main.cc
+++ b/src/control-node/main.cc
@@ -592,7 +592,14 @@ int main(int argc, char *argv[]) {
             tcp::resolver::iterator iter = resolver.resolve(query);
             self_ip = iter->endpoint().address().to_string();
         }
-        ControlNode::SetSelfIp(self_ip);
+
+        // verify string is a valid ip before publishing
+        boost::asio::ip::address::from_string(self_ip, error);
+        if (error) {
+            self_ip.clear();
+        } else { 
+            ControlNode::SetSelfIp(self_ip);
+        }
 
         if (!self_ip.empty()) {
             stringstream pub_ss;


### PR DESCRIPTION
Verify ipaddress of self-ip parsed while launching daemon is valid, this check is needed as invalid ip string is published to Discovery Server, which inturn sends this to the subscribers.
