### PR TITLE
Changes to remove the viz_constants.cpp file included in query.cc

### DIFF
--- a/src/query_engine/SConscript
+++ b/src/query_engine/SConscript
@@ -140,7 +140,7 @@ qed = env.Program(
         target = 'qed', 
         source = qed_objs + qed_except_objs + build_obj +
         SandeshGenObjs +  RedisConn_obj +
-        ['../analytics/vizd_table_desc.o', 'rac_alloc.cc']
+        ['../analytics/vizd_table_desc.o', 'rac_alloc.cc', '../analytics/viz_constants.o']
         )
 
 if env['OPT'] == 'coverage':
@@ -148,7 +148,7 @@ if env['OPT'] == 'coverage':
         target = 'qedt', 
         source = qed_objs + qed_except_objs + build_obj +
         SandeshGenObjs +  RedisConn_obj + 
-        ['../analytics/vizd_table_desc.o', 'rac_alloc.cc']
+        ['../analytics/vizd_table_desc.o', 'rac_alloc.cc','../analytics/viz_constants.o']
         )
 
 else:
@@ -157,7 +157,7 @@ else:
         source = qed_objs + qed_except_objs + build_obj +
         SandeshGenObjs +  RedisConn_obj +
         ['../analytics/vizd_table_desc.o', ] +
-        ['rac_alloc_test.cc']
+        ['rac_alloc_test.cc','../analytics/viz_constants.o']
         )
 
 env.Alias("src/query_engine:qed", qed)

--- a/src/query_engine/query.cc
+++ b/src/query_engine/query.cc
@@ -12,7 +12,6 @@
 #include "rapidjson/document.h"
 #include "base/logging.h"
 #include "query.h"
-#include "viz_constants.cpp"
 #include <boost/assign/list_of.hpp>
 #include <cerrno>
 #include "analytics/vizd_table_desc.h"


### PR DESCRIPTION
Changes to remove the viz_constants.cpp file from being included in query.cc Instead add the object file when building the targets
