### PR TITLE
* Erase service vlan entry only upon config delete, upon deactivation

### DIFF
--- a/src/vnsw/agent/oper/vm_interface.cc
+++ b/src/vnsw/agent/oper/vm_interface.cc
@@ -1180,7 +1180,9 @@ void VmInterface::DeleteFloatingIp() {
     while (it != floating_ip_list_.list_.end()) {
         FloatingIpSet::iterator prev = it++;
         prev->DeActivate(this);
-        floating_ip_list_.list_.erase(prev);
+        if (prev->del_pending_) {
+            floating_ip_list_.list_.erase(prev);
+        }
     }
 }
 
@@ -1202,7 +1204,9 @@ void VmInterface::DeleteServiceVlan() {
     while (it != service_vlan_list_.list_.end()) {
         ServiceVlanSet::iterator prev = it++;
         prev->DeActivate(this);
-        service_vlan_list_.list_.erase(prev);
+        if (prev->del_pending_) {
+            service_vlan_list_.list_.erase(prev);
+        }
     }
 } 
 
@@ -1224,7 +1228,9 @@ void VmInterface::DeleteStaticRoute() {
     while (it != static_route_list_.list_.end()) {
         StaticRouteSet::iterator prev = it++;
         prev->DeActivate(this);
-        static_route_list_.list_.erase(prev);
+        if (prev->del_pending_) {
+            static_route_list_.list_.erase(prev);
+        }
     }
 }
 
@@ -1244,7 +1250,9 @@ void VmInterface::DeleteSecurityGroup() {
     SecurityGroupEntrySet::iterator it = sg_list_.list_.begin();
     while (it != sg_list_.list_.end()) {
         SecurityGroupEntrySet::iterator prev = it++;
-        sg_list_.list_.erase(prev);
+        if (prev->del_pending_) {
+            sg_list_.list_.erase(prev);
+        }
     }
 }
 


### PR DESCRIPTION
  of interface just delete route.
  Fixes ecmp test case failure.
