### PR TITLE
Unit tests to verify relative_time were not calling the parse_time

### DIFF
--- a/src/opserver/test/analytics_perftest.py
+++ b/src/opserver/test/analytics_perftest.py
@@ -46,34 +46,6 @@ class cd:
     def __exit__(self, etype, value, traceback):
         os.chdir(self.savedPath)
 
-class Query(object):
-    table = None
-    start_time = None
-    end_time = None
-    select_fields = None
-    where = None
-    sort = None
-    sort_fields = None
-    limit = None
-    filter = None
-
-    def __init__(self, table, start_time, end_time, select_fields, where = None,
-            sort_fields = None, sort = None, limit = None, filter = None):
-        self.table = table
-        self.start_time = start_time
-        self.end_time = end_time
-        self.select_fields = select_fields
-        if where is not None:
-            self.where = where
-        if sort_fields is not None:
-            self.sort_fields = sort_fields
-        if sort is not None:
-            self.sort = sort
-        if limit is not None:
-            self.limit = limit
-        if filter is not None:
-            self.filter = filter
-
 class AnalyticsTest(testtools.TestCase, fixtures.TestWithFixtures):
     @classmethod
     def setUpClass(cls):

--- a/src/opserver/test/utils/analytics_fixture.py
+++ b/src/opserver/test/utils/analytics_fixture.py
@@ -11,9 +11,38 @@ import redis
 import urllib2
 import copy
 import os
+import json
 from operator import itemgetter
 from opserver_introspect_utils import VerificationOpsSrv
 from collector_introspect_utils import VerificationCollector
+
+class Query(object):
+    table = None
+    start_time = None
+    end_time = None
+    select_fields = None
+    where = None
+    sort = None
+    sort_fields = None
+    limit = None
+    filter = None
+
+    def __init__(self, table, start_time, end_time, select_fields, where = None,
+            sort_fields = None, sort = None, limit = None, filter = None):
+        self.table = table
+        self.start_time = start_time
+        self.end_time = end_time
+        self.select_fields = select_fields
+        if where is not None:
+            self.where = where
+        if sort_fields is not None:
+            self.sort_fields = sort_fields
+        if sort is not None:
+            self.sort = sort
+        if limit is not None:
+            self.limit = limit
+        if filter is not None:
+            self.filter = filter
 
 class Collector(object):
     def __init__(self, analytics_fixture, logger, is_dup=False):
@@ -979,11 +1008,13 @@ class AnalyticsFixture(fixtures.Fixture):
     def verify_fieldname_messagetype(self):
         self.logger.info('Verify stats table for stats name field');
         vns = VerificationOpsSrv('127.0.0.1', self.opserver_port);
-        res = vns.post_query('StatTable.FieldNames.fields',
-                             start_time='-10m',
-                             end_time='now',
-                             select_fields=['fields.value'],
-                             where_clause='name=MessageTable*')
+        query = Query(table="StatTable.FieldNames.fields",
+		            start_time="now-10m",
+                            end_time="now",
+                            select_fields=["fields.value"],
+                            where=[[{"name": "name", "value": "Message", "op": 7}]])
+	json_qstr = json.dumps(query.__dict__)
+	res = vns.post_query_json(json_qstr)
         self.logger.info(str(res))
         assert(len(res)>1)
         return True
@@ -991,11 +1022,13 @@ class AnalyticsFixture(fixtures.Fixture):
     def verify_fieldname_objecttype(self):
         self.logger.info('Verify stats table for stats name field');
         vns = VerificationOpsSrv('127.0.0.1', self.opserver_port);
-        res = vns.post_query('StatTable.FieldNames.fields',
-                             start_time='-10m',
-                             end_time='now',
-                             select_fields=['fields.value'],
-                             where_clause='name=Object*')
+        query = Query(table="ObjectGeneratorInfo",
+                            start_time="now-600s",
+                            end_time="now",
+                            select_fields=["ObjectId"],
+                            where=[[{"name":"ObjectId","value":"a6s9","op":1}]])
+        json_qstr = json.dumps(query.__dict__)
+        res = vns.post_query_json(json_qstr)
         self.logger.info(str(res))
         assert(len(res) > 1)
         return True


### PR DESCRIPTION
function in query.cc as expected. Changing the way we post query
made the the function to be called properly. Also the UT has been
added to check OBJECT_VALUE_TABLE.
Code changes:
Query class has been moved from perftest.py to analytics_fixture.py
as it is used elsewhere and util would be a proper place.
Instead of query query_json objects are called so that passed parameters
are not interpreted by the util scripts before calling the actual functions.
Test:
Coverage report shows the parse_time function being referred in query.cc
