### PR TITLE
fix for bug 2326.

### DIFF
--- a/src/bgp/bgp_config.cc
+++ b/src/bgp/bgp_config.cc
@@ -887,7 +887,9 @@ void BgpConfigManager::ProcessRoutingInstance(const BgpConfigDelta &delta) {
     } else {
         IFMapNode *node = rti->node();
         if (node == NULL) {
-            rti->SetNodeProxy(delta.node.get());
+            IFMapNodeProxy *proxy = delta.node.get();
+            if (proxy == NULL) return;
+            rti->SetNodeProxy(proxy);
         } else if (node->IsDeleted() || !node->HasAdjacencies(db_graph_)) {
             rti->ResetConfig();
             if (rti->DeleteIfEmpty(this)) {

--- a/src/ifmap/ifmap_node_proxy.cc
+++ b/src/ifmap/ifmap_node_proxy.cc
@@ -44,5 +44,6 @@ void IFMapNodeProxy::Clear() {
     if (node_ != NULL) {
         node_->ClearState(node_->table(), id_);
         node_ = NULL;
+        id_ = DBTable::kInvalidId;
     }
 }


### PR DESCRIPTION
 If the default VRF delete event is added twice to change list, bgp config manager tries to access NULL pointer. Also added code to reset the listener id in IfMapNodeProxy::Clear(). It is confusing to have node pointer set to null and listener id set to valid id.
