### PR TITLE
1. Accept ARP replies even when agent has not sent ARP request. Add UT f...

### DIFF
--- a/src/vnsw/agent/services/arp_entry.cc
+++ b/src/vnsw/agent/services/arp_entry.cc
@@ -112,6 +112,7 @@ void ArpEntry::StartTimer(uint32_t timeout, ArpHandler::ArpMsgType mtype) {
 }
 
 void ArpEntry::SendArpRequest() {
+    const unsigned char zero_mac[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     Agent *agent = handler_->agent();
     ArpProto *arp_proto = agent->GetArpProto();
     uint16_t itf_index = arp_proto->ip_fabric_interface_index();
@@ -119,7 +120,7 @@ void ArpEntry::SendArpRequest() {
     Ip4Address ip = agent->GetRouterId();
 
     handler_->SendArp(ARPOP_REQUEST, smac, ip.to_ulong(), 
-                      mac_address_, key_.ip, itf_index, 
+                      zero_mac, key_.ip, itf_index, 
                       agent->GetVrfTable()->FindVrfFromName(
                           agent->GetDefaultVrf())->GetVrfId());
 

--- a/src/vnsw/agent/services/arp_handler.cc
+++ b/src/vnsw/agent/services/arp_handler.cc
@@ -155,8 +155,15 @@ bool ArpHandler::HandlePacket() {
             arp_proto->StatsArpReplies();
             if (entry) {
                 entry->HandleArpReply(arp_->arp_sha);
+                return true;
+            } else {
+                entry = new ArpEntry(io_, this, arp_tpa_, vrf);
+                arp_proto->AddArpEntry(entry->key(), entry);
+                delete[] pkt_info_->pkt;
+                pkt_info_->pkt = NULL;
+                entry->HandleArpReply(arp_->arp_sha);
+                return false;
             }
-            return true;
         }
 
         case GRATUITOUS_ARP: {
@@ -309,5 +316,5 @@ void ArpHandler::SendArp(uint16_t op, const unsigned char *smac, in_addr_t sip,
     ArpHdr(smac, sip, tmac, tip, op);
     EthHdr(smac, bcast_mac, 0x806);
 
-    Send(MIN_ETH_PKT_LEN, itf, vrf, AGENT_CMD_SWITCH, PktHandler::ARP);
+    Send(sizeof(ethhdr) + sizeof(ether_arp), itf, vrf, AGENT_CMD_SWITCH, PktHandler::ARP);
 }

--- a/src/vnsw/agent/services/test/arp_test.cc
+++ b/src/vnsw/agent/services/test/arp_test.cc
@@ -171,12 +171,17 @@ public:
         Agent::GetInstance()->pkt()->pkt_handler()->SendMessage(PktHandler::ARP, ipc);
     }
 
-    bool FindArpNHEntry(uint32_t addr, const string &vrf_name) {
+    bool FindArpNHEntry(uint32_t addr, const string &vrf_name, bool validate = false) {
         Ip4Address ip(addr);
         ArpNHKey key(vrf_name, ip);
-        if (Agent::GetInstance()->GetNextHopTable()->FindActiveEntry(&key))
+        ArpNH *arp_nh = static_cast<ArpNH *>(Agent::GetInstance()->
+                                             GetNextHopTable()->
+                                             FindActiveEntry(&key));
+        if (arp_nh) {
+            if (validate)
+                return arp_nh->IsValid();
             return true;
-        else
+        } else
             return false;
     }
 
@@ -196,7 +201,7 @@ public:
             return false;
     }
 
-    void ArpNH(DBRequest::DBOperation op, in_addr_t addr) {
+    void ArpNHUpdate(DBRequest::DBOperation op, in_addr_t addr) {
         Ip4Address ip(addr);
         ether_addr mac;
         Inet4UnicastAgentRouteTable::ArpRoute(op, ip, mac, 
@@ -326,6 +331,7 @@ TEST_F(ArpTest, ArpGraciousTest) {
 TEST_F(ArpTest, ArpTunnelGwTest) {
     TunnelNH(DBRequest::DB_ENTRY_ADD_CHANGE, src_ip,
                        ntohl(inet_addr(DIFF_NET_IP)));
+    SendArpReq(req_ifindex, 0, src_ip, gw_ip);
     WaitForCompletion(1);
     SendArpReply(reply_ifindex, 0, src_ip, gw_ip);
     WaitForCompletion(1);
@@ -341,7 +347,7 @@ TEST_F(ArpTest, ArpDelTest) {
     WaitForCompletion(2);
     EXPECT_TRUE(FindArpNHEntry(ntohl(inet_addr(GRAT_IP)), Agent::GetInstance()->GetDefaultVrf()));
     EXPECT_TRUE(FindArpRoute(ntohl(inet_addr(GRAT_IP)), Agent::GetInstance()->GetDefaultVrf()));
-    ArpNH(DBRequest::DB_ENTRY_DELETE, ntohl(inet_addr(GRAT_IP)));
+    ArpNHUpdate(DBRequest::DB_ENTRY_DELETE, ntohl(inet_addr(GRAT_IP)));
     client->WaitForIdle();
     usleep(175000);
     EXPECT_EQ(1U, Agent::GetInstance()->GetArpProto()->GetArpCacheSize());
@@ -351,12 +357,30 @@ TEST_F(ArpTest, ArpDelTest) {
 
 TEST_F(ArpTest, ArpTunnelTest) {
     TunnelNH(DBRequest::DB_ENTRY_ADD_CHANGE, src_ip, dest_ip);
+    SendArpReq(req_ifindex, 0, src_ip, dest_ip);
     WaitForCompletion(2);
     SendArpReply(reply_ifindex, 0, src_ip, dest_ip);
     WaitForCompletion(2);
     EXPECT_TRUE(FindArpNHEntry(dest_ip, Agent::GetInstance()->GetDefaultVrf()));
     EXPECT_TRUE(FindArpRoute(dest_ip, Agent::GetInstance()->GetDefaultVrf()));
     TunnelNH(DBRequest::DB_ENTRY_DELETE, src_ip, dest_ip);
+    client->WaitForIdle();
+    SendArpMessage(ArpHandler::AGING_TIMER_EXPIRED, dest_ip);
+    usleep(175000);
+    EXPECT_EQ(1U, Agent::GetInstance()->GetArpProto()->GetArpCacheSize());
+    EXPECT_FALSE(FindArpNHEntry(dest_ip, Agent::GetInstance()->GetDefaultVrf()));
+    EXPECT_FALSE(FindArpRoute(dest_ip, Agent::GetInstance()->GetDefaultVrf()));
+}
+
+TEST_F(ArpTest, ArpTunnelNoRequestTest) {
+    // Send Arp reply first to check that entry is created
+    SendArpReply(reply_ifindex, 0, src_ip, dest_ip);
+    WaitForCompletion(2);
+    EXPECT_TRUE(FindArpNHEntry(dest_ip, Agent::GetInstance()->GetDefaultVrf(), true));
+    EXPECT_TRUE(FindArpRoute(dest_ip, Agent::GetInstance()->GetDefaultVrf()));
+    // TunnelNH(DBRequest::DB_ENTRY_ADD_CHANGE, src_ip, dest_ip);
+    // WaitForCompletion(2);
+    // TunnelNH(DBRequest::DB_ENTRY_DELETE, src_ip, dest_ip);
     client->WaitForIdle();
     SendArpMessage(ArpHandler::AGING_TIMER_EXPIRED, dest_ip);
     usleep(175000);


### PR DESCRIPTION
...or same
1. Send target hw-address to zero's in all cases
2. Dont pad ARP packet to 64 bytes. Set size of ARP packet to 42 bytes
3. Fix crash in meta-data if we get response after TCP session close
