### PR TITLE
Mark the flow entry as short flow ENOSPC or EBADF failures

### DIFF
--- a/src/vnsw/agent/ksync/sandesh_ksync.cc
+++ b/src/vnsw/agent/ksync/sandesh_ksync.cc
@@ -78,6 +78,14 @@ void KSyncSandeshContext::FlowMsgHandler(vr_flow_req *r) {
                        << " proto = " << (int)key.protocol);
             if (entry && (int)entry->flow_handle() == r->get_fr_index()) {
                 entry->set_flow_handle(FlowEntry::kInvalidFlowHandle);
+                entry->MakeShortFlow();
+            }
+            return;
+        }
+
+        if (GetErrno() == ENOSPC) {
+            if (entry) {
+                entry->MakeShortFlow();
             }
             return;
         }


### PR DESCRIPTION
while program entry in vrouter. So it can be deleted in next aging cycle.

fixes bug - 2340
