### PR TITLE
Use monotonic_deadline_timer instead of deadline_timer for our timer imp...

### DIFF
--- a/src/base/SConscript
+++ b/src/base/SConscript
@@ -14,6 +14,9 @@ if '-fno-exceptions' in cflags:
     cflags.remove('-fno-exceptions')
 except_env.Replace(CCFLAGS = cflags)
 
+timer_env = BuildEnv.Clone()
+timer_env.AppendUnique(CCFLAGS='-DBOOST_CHRONO_HEADER_ONLY')
+
 CpuInfoSandeshGenFiles = env.SandeshGenCpp('sandesh/cpuinfo.sandesh')
 CpuInfoSandeshGenSrcs = env.ExtractCpp(CpuInfoSandeshGenFiles)
 
@@ -28,9 +31,11 @@ env.Append(CPPPATH = env['TOP'])
 libcpuinfo = env.Library('cpuinfo', ['cpuinfo.cc'] + cpuinfo_sandesh_files_)
 
 task = except_env.Object('task.o', 'task.cc')
+timer = timer_env.Object('timer.o', 'timer.cc')
 
 VersionInfoSandeshGenFiles = env.SandeshGenCpp('sandesh/version.sandesh')
 VersionInfoSandeshGenSrcs = env.ExtractCpp(VersionInfoSandeshGenFiles)
+
 
 libbase = env.Library('base',
                       [VersionInfoSandeshGenSrcs +
@@ -44,7 +49,7 @@ libbase = env.Library('base',
                        task,
                        'task_annotations.cc',
                        'task_trigger.cc',
-                       'timer.cc'
+                       timer,
                        ]])
 env.Requires(libbase, '#/build/lib/liblog4cplus.a')
 env.Requires(libbase, '#/build/include/boost')

--- a/src/base/timer.cc
+++ b/src/base/timer.cc
@@ -71,7 +71,7 @@ private:
 
 Timer::Timer(boost::asio::io_service &service, const std::string &name,
           int task_id, int task_instance)
-    : boost::asio::deadline_timer(service), name_(name), handler_(NULL),
+    : boost::asio::monotonic_deadline_timer(service), name_(name), handler_(NULL),
     error_handler_(NULL), state_(Init), timer_task_(NULL), time_(0),
     task_id_(task_id), task_instance_(task_instance), seq_no_(0) {
     refcount_ = 0;
@@ -136,7 +136,7 @@ bool Timer::Cancel() {
 }
 
 // ASIO callback on timer expiry. Start a task to serve the timer
-void Timer::StartTimerTask(boost::asio::deadline_timer* t, TimerPtr timer,
+void Timer::StartTimerTask(boost::asio::monotonic_deadline_timer* t, TimerPtr timer,
                            int time, uint32_t seq_no, 
                            const boost::system::error_code &ec) {
     tbb::mutex::scoped_lock lock(timer->mutex_);

--- a/src/base/timer.h
+++ b/src/base/timer.h
@@ -45,10 +45,11 @@
 #include <boost/asio.hpp>
 #include <boost/system/error_code.hpp>
 #include <set>
+#include <boost/asio/monotonic_deadline_timer.hpp>
 
 #include <base/task.h>
 
-class Timer : public boost::asio::deadline_timer {
+class Timer : public boost::asio::monotonic_deadline_timer {
 private:
 	// Task used to fire the timer
     class TimerTask;
@@ -119,7 +120,7 @@ private:
     };
 
     // ASIO callback on timer expiry. Start a task to serve the timer
-    static void StartTimerTask(boost::asio::deadline_timer* t, TimerPtr t_ptr,
+    static void StartTimerTask(boost::asio::monotonic_deadline_timer* t, TimerPtr t_ptr,
                                int time, uint32_t seq_no,
                                const boost::system::error_code &ec);
 


### PR DESCRIPTION
...lementation of timers. The deadline_timer used earlier was resulting in an issue of timers not getting fired when time is changed backwards.
