### PR TITLE
When vrf is dis-associated from VN, we need to send 0 length vrf_stats_l...

### DIFF
--- a/src/vnsw/agent/uve/test/test_uve_util.h
+++ b/src/vnsw/agent/uve/test/test_uve_util.h
@@ -59,10 +59,11 @@ public:
         char vrf_name[80];
 
         sprintf(vrf_name, "vrf%d", id);
+        client->Reset();
+        EXPECT_FALSE(VrfFind(vrf_name));
         AddVrf(vrf_name);
-        client->WaitForIdle();
-        EXPECT_TRUE(client->VrfNotifyWait(1));
-        EXPECT_TRUE(VrfFind(vrf_name));
+        client->WaitForIdle(3);
+        WAIT_FOR(1000, 5000, (VrfFind(vrf_name) == true));
     }
 
     void NovaPortAdd(struct PortInfo *input) {

--- a/src/vnsw/agent/uve/test/test_vm_uve.cc
+++ b/src/vnsw/agent/uve/test/test_vm_uve.cc
@@ -156,6 +156,31 @@ TEST_F(UveVmUveTest, VmIntfAddDel_1) {
     EXPECT_EQ(3U, vmut->send_count());
     EXPECT_EQ(0U, uve1->get_interface_list().size()); 
 
+    //Activate the interface again
+    AddLink("virtual-machine-interface-routing-instance", "vnet1",
+            "routing-instance", "vrf1");
+    AddLink("virtual-machine-interface-routing-instance", "vnet1",
+            "virtual-machine-interface", "vnet1");
+    client->WaitForIdle();
+
+    //Verify UVE 
+    EXPECT_EQ(4U, vmut->send_count());
+    EXPECT_EQ(1U, uve1->get_interface_list().size()); 
+
+    // Delete virtual-machine-interface to vrf link attribute
+    DelLink("virtual-machine-interface-routing-instance", "vnet1",
+            "routing-instance", "vrf1");
+    DelLink("virtual-machine-interface-routing-instance", "vnet1",
+            "virtual-machine-interface", "vnet1");
+    client->WaitForIdle();
+
+    //Verify that the port is inactive
+    EXPECT_TRUE(VmPortInactive(input, 0));
+
+    //Verify UVE 
+    EXPECT_EQ(5U, vmut->send_count());
+    EXPECT_EQ(0U, uve1->get_interface_list().size()); 
+
     //other cleanup
     util_.VnDelete(input[0].vn_id);
     DelLink("virtual-machine", "vm1", "virtual-machine-interface", "vnet1");

--- a/src/vnsw/agent/uve/vn_uve_entry.cc
+++ b/src/vnsw/agent/uve/vn_uve_entry.cc
@@ -460,6 +460,13 @@ bool VnUveEntry::UpdateVrfStats(const VnEntry *vn,
     VrfEntry *vrf = vn->GetVrf();
     if (vrf) {
         changed = FillVrfStats(vrf->GetVrfId(), s_vn);
+    } else {
+        vector<UveVrfStats> vlist;
+        if (UveVnVrfStatsChanged(vlist)) {
+            s_vn.set_vrf_stats_list(vlist);
+            uve_info_.set_vrf_stats_list(vlist);
+            changed = true;
+        }
     }
 
     return changed;


### PR DESCRIPTION
...ist instead of not sending vrf_stats_list. Also add UT for this.
