### PR TITLE
Vm-reg followed by a xmpp-not-ready message causes the client to go away...

### DIFF
--- a/src/ifmap/ifmap_server.cc
+++ b/src/ifmap/ifmap_server.cc
@@ -239,7 +239,7 @@ bool IFMapServer::ProcessClientWork(bool add, IFMapClient *client) {
     } else {
         ClientGraphCleanup(client);
         RemoveSelfAddedLinks(client);
-        vm_uuid_mapper_->CleanupPendingVmRegMaps(client->identifier());
+        CleanupUuidMapper(client);
         ClientUnregister(client);
     }
     return true;
@@ -295,6 +295,15 @@ void IFMapServer::LinkResetClient(DBGraphEdge *edge, const BitSet &bset) {
     if (state) {
         state->InterestReset(bset);
         state->AdvertisedReset(bset);
+    }
+}
+
+// Get the list of subscribed VMs. For each item in the list, if it exist in the
+// list of pending vm registration requests, remove it.
+void IFMapServer::CleanupUuidMapper(IFMapClient *client) {
+    std::vector<std::string> vmlist = client->vm_list();
+    for (size_t count = 0; count < vmlist.size(); ++count) {
+        vm_uuid_mapper_->CleanupPendingVmRegEntry(vmlist.at(count));
     }
 }
 

--- a/src/ifmap/ifmap_server.h
+++ b/src/ifmap/ifmap_server.h
@@ -115,6 +115,7 @@ private:
     void ClientGraphDownload(IFMapClient *client);
     void ClientGraphCleanup(IFMapClient *client);
     void RemoveSelfAddedLinks(IFMapClient *client);
+    void CleanupUuidMapper(IFMapClient *client);
     void LinkResetClient(DBGraphEdge *edge, const BitSet &bset);
     void NodeResetClient(DBGraphVertex *vertex, const BitSet &bset);
     bool StaleNodesProcTimeout();

--- a/src/ifmap/ifmap_uuid_mapper.cc
+++ b/src/ifmap/ifmap_uuid_mapper.cc
@@ -139,9 +139,8 @@ void IFMapVmUuidMapper::VmNodeProcess(DBTablePartBase *partition,
             if (exists) {
                 bool subscribe = true;
                 ifmap_server_->ProcessVmSubscribe(vr_name, vm_node->name(),
-                                                subscribe);
+                                                  subscribe);
                 pending_vmreg_map_.erase(vm_uuid);
-                ErasePendingVrVmRegMapEntry(vr_name, vm_uuid);
             }
         }
     }
@@ -163,46 +162,8 @@ void IFMapVmUuidMapper::ProcessVmRegAsPending(std::string vm_uuid,
         std::string vr_name, bool subscribe) {
     if (subscribe) {
         pending_vmreg_map_.insert(make_pair(vm_uuid, vr_name));
-        pending_vrvm_reg_map_.insert(make_pair(vr_name, vm_uuid));
     } else {
         pending_vmreg_map_.erase(vm_uuid);
-        ErasePendingVrVmRegMapEntry(vr_name, vm_uuid);
-    }
-}
-
-// Remove one entry corresponding to [vr_name, vm_uuid] from
-// pending_vrvm_reg_map_.
-void IFMapVmUuidMapper::ErasePendingVrVmRegMapEntry(const std::string &vr_name,
-                                                   const std::string &vm_uuid) {
-    size_t count = pending_vrvm_reg_map_.count(vr_name);
-    assert(count);
-    std::pair<PendingVrVmRegMap::iterator, PendingVrVmRegMap::iterator> range;
-    range = pending_vrvm_reg_map_.equal_range(vr_name);
-    for (PendingVrVmRegMap::iterator iter = range.first; iter != range.second;
-         ++iter) {
-        if (iter->second == vm_uuid) {
-            pending_vrvm_reg_map_.erase(iter);
-            break;
-        }
-    }
-}
-
-// Called when the client is going away i.e. xmpp-not-ready was received
-void IFMapVmUuidMapper::CleanupPendingVmRegMaps(const std::string &vr_name) {
-    size_t count = pending_vrvm_reg_map_.count(vr_name);
-    if (count) {
-        std::pair<PendingVrVmRegMap::iterator,
-                  PendingVrVmRegMap::iterator> range;
-        range = pending_vrvm_reg_map_.equal_range(vr_name);
-        // Find all the vm's who have been registered but are still pending
-        // creation and clean them up one by one.
-        for (PendingVrVmRegMap::iterator iter = range.first;
-             iter != range.second; ++iter) {
-            // iter->second is the vm_uuid
-            pending_vmreg_map_.erase(iter->second);
-        }
-        // In one shot, cleanup all the entries with key 'vr-name'
-        pending_vrvm_reg_map_.erase(vr_name);
     }
 }
 

--- a/src/ifmap/ifmap_uuid_mapper.h
+++ b/src/ifmap/ifmap_uuid_mapper.h
@@ -47,10 +47,6 @@ public:
     // Store [vm-uuid, vr-name] from the vm-reg request
     // ADD: vm-reg-request, DELETE: vm-node add/xmpp-not-ready
     typedef std::map<std::string, std::string> PendingVmRegMap;
-    // Store [vr-name, vm-uuid] from the vm-reg request
-    // Note, each vr-name can have multiple vm's and hence multimap
-    // ADD: vm-reg-request, DELETE: vm-node add/xmpp-not-ready
-    typedef std::multimap<std::string, std::string> PendingVrVmRegMap;
     // Store [vm-node, vm-uuid]. Used to clean-up uuid_mapper_'s 'vm-uuid'
     // entry when the vm-node becomes InFeasible. The objects would be gone by
     // then and the uuid would not be available from the node.
@@ -82,8 +78,8 @@ public:
     PendingVmRegMap::size_type PendingVmRegCount() {
         return pending_vmreg_map_.size();
     }
-    PendingVrVmRegMap::size_type PendingVrVmRegCount() {
-        return pending_vrvm_reg_map_.size();
+    void CleanupPendingVmRegEntry(const std::string &vm_uuid) {
+        pending_vmreg_map_.erase(vm_uuid);
     }
     void PrintAllPendingVmRegEntries();
 
@@ -93,7 +89,6 @@ public:
         return node_uuid_map_.size();
     }
     void PrintAllNodeUuidMappedEntries();
-    void CleanupPendingVmRegMaps(const std::string &vr_name);
 
 private:
     friend class IFMapVmUuidMapperTest;
@@ -110,12 +105,9 @@ private:
     IFMapUuidMapper uuid_mapper_;
     NodeUuidMap node_uuid_map_;
     PendingVmRegMap pending_vmreg_map_;
-    PendingVrVmRegMap pending_vrvm_reg_map_;
 
     // TODO: consider moving the common parts inside IFMapNode
     bool IsFeasible(IFMapNode *node);
-    void ErasePendingVrVmRegMapEntry(const std::string &vr_name,
-                                     const std::string &vm_uuid);
 };
 
 #endif /* __IFMAP_UUID_MAPPER_H__ */

--- a/src/ifmap/test/ifmap_xmpp_test.cc
+++ b/src/ifmap/test/ifmap_xmpp_test.cc
@@ -1412,16 +1412,12 @@ TEST_F(XmppIfmapTest, VrVmSubConnClose) {
     vnsw_client->SendVmConfigSubscribe(HOST_VM_NAME1);
     usleep(1000);
     TASK_UTIL_EXPECT_EQ(ifmap_server_.vm_uuid_mapper()->PendingVmRegCount(), 1);
-    TASK_UTIL_EXPECT_EQ(ifmap_server_.vm_uuid_mapper()->PendingVrVmRegCount(),
-                        1);
-
     EXPECT_EQ(ifmap_server_.GetClientMapSize(), 1);
+
     // Client close generates a TcpClose event on server
     ConfigUpdate(vnsw_client, new XmppConfigData());
     TASK_UTIL_EXPECT_EQ(ifmap_server_.GetClientMapSize(), 0);
     TASK_UTIL_EXPECT_EQ(ifmap_server_.vm_uuid_mapper()->PendingVmRegCount(), 0);
-    TASK_UTIL_EXPECT_EQ(ifmap_server_.vm_uuid_mapper()->PendingVrVmRegCount(),
-                        0);
 
     // Verify ifmap_server client cleanup
     EXPECT_EQ(true, IsIFMapClientUnregistered(&ifmap_server_, client_name));


### PR DESCRIPTION
.... But,

the pending_vmreg_map_ is not cleaned up when the client is going away. When
the xmpp-not-ready message is later followed by the vm-node create, the code
will attempt to find the client and fail. Fixing this by cleaning up the
pending_vmreg_map_ when we get the xmpp-not-ready message. To do this, we are
keeping track of the each vr-vm reg request in a multimap and we use this to
lookup the vm and cleanup the pending_vmreg_map_.
