### PR TITLE
Add source/destination address types for ACL Introspection query

### DIFF
--- a/src/vnsw/agent/filter/acl_entry.cc
+++ b/src/vnsw/agent/filter/acl_entry.cc
@@ -288,23 +288,30 @@ void AddressMatch::SetAclEntryMatchSandeshData(AclEntrySandeshData &data)
 {
 
     std::string *str;
+    std::string *addr_type_str;
 
     if (src_) {
         str = &data.src;
+        addr_type_str = &data.src_type;
     } else {
         str = &data.dst;
+        addr_type_str = &data.dst_type;
     }
 
     if (addr_type_ == IP_ADDR) {
         *str = (ip_addr_.to_string() + " " + ip_mask_.to_string());
+        *addr_type_str = "ip";
     } else if (addr_type_ == NETWORK_ID) {
         *str = policy_id_s_;
+        *addr_type_str = "network";
     } else if (addr_type_ == SG) {
         std::ostringstream ss;
         ss << sg_id_;
         *str = ss.str();
+        *addr_type_str = "sg";
     } else {
         *str = "Unknown Address Type";
+        *addr_type_str = "unknown";
     }
     return;
 

--- a/src/vnsw/agent/filter/test/acl_entry_test.cc
+++ b/src/vnsw/agent/filter/test/acl_entry_test.cc
@@ -374,6 +374,170 @@ TEST_F(AclEntryTest, BasicDeny) {
     delete entry1;
 }
 
+TEST_F(AclEntryTest, BasicIntrospecIpAclEntry) {
+    AclEntrySpec ae_spec1;
+    ae_spec1.id = 1;
+    ae_spec1.src_ip_addr = IpAddress::from_string("2.2.2.0");
+    ae_spec1.src_ip_mask = IpAddress::from_string("255.255.255.0");
+    ae_spec1.src_addr_type = AddressMatch::IP_ADDR; 
+    RangeSpec protocol;
+    protocol.min = 10;
+    protocol.max = 10;
+    ae_spec1.protocol.push_back(protocol);
+    RangeSpec port;
+    port.min = 10;
+    port.max = 100;
+    ae_spec1.dst_port.push_back(port);
+    ae_spec1.terminal = true;
+    ActionSpec action;
+    action.ta_type = TrafficAction::SIMPLE_ACTION;
+    action.simple_action = TrafficAction::DENY;
+    ae_spec1.action_l.push_back(action);
+
+    AclEntry entry1;
+    PacketHeader packet1;
+    packet1.src_ip = 0x02020202;
+    packet1.protocol = 10;
+    packet1.dst_port = 99;
+    entry1.PopulateAclEntry(ae_spec1);
+    AclEntry::ActionList al;
+    al = entry1.PacketMatch(packet1);
+    AclEntry::ActionList::iterator ial;
+    ial = al.begin();
+    EXPECT_EQ(1U, al.size());
+    EXPECT_EQ(SimpleAction::DENY, static_cast<SimpleAction *>(*ial.operator->())->GetAction());
+    AclEntrySandeshData data;
+    entry1.SetAclEntrySandeshData(data);
+    EXPECT_EQ(data.src_type, "ip");
+    EXPECT_EQ(data.dst_port_l.size(), 1);
+    EXPECT_EQ(data.dst_port_l.begin()->min, 10);
+    EXPECT_EQ(data.dst_port_l.begin()->max, 100);
+    EXPECT_EQ(data.proto_l.size(), 1);
+    EXPECT_EQ(data.proto_l.begin()->min, 10);
+    EXPECT_EQ(data.proto_l.begin()->max, 10);
+    EXPECT_EQ(data.src, "2.2.2.0 255.255.255.0");
+}
+
+TEST_F(AclEntryTest, BasicIntrospecNetworkAclEntry) {
+    AclEntrySpec ae_spec1;
+    ae_spec1.id = 1;
+    ae_spec1.src_policy_id_str = "network1";
+    ae_spec1.src_addr_type = AddressMatch::NETWORK_ID;
+    ae_spec1.dst_policy_id_str = "network2";
+    ae_spec1.dst_addr_type = AddressMatch::NETWORK_ID;
+    RangeSpec protocol;
+    protocol.min = 10;
+    protocol.max = 10;
+    ae_spec1.protocol.push_back(protocol);
+    RangeSpec src_port;
+    src_port.min = 100;
+    src_port.max = 1000;
+    ae_spec1.src_port.push_back(src_port);
+    RangeSpec dst_port;
+    dst_port.min = 10;
+    dst_port.max = 100;
+    ae_spec1.dst_port.push_back(dst_port);
+    ae_spec1.terminal = true;
+    ActionSpec action;
+    action.ta_type = TrafficAction::SIMPLE_ACTION;
+    action.simple_action = TrafficAction::PASS;
+    ae_spec1.action_l.push_back(action);
+
+    AclEntry entry1;
+    PacketHeader packet1;
+    std::string src_network("network1");
+    std::string dst_network("network2");
+    packet1.src_policy_id = &src_network;
+    packet1.dst_policy_id = &dst_network;
+    packet1.protocol = 10;
+    packet1.dst_port = 99;
+    packet1.src_port  = 101;
+    entry1.PopulateAclEntry(ae_spec1);
+    AclEntry::ActionList al;
+    al = entry1.PacketMatch(packet1);
+    AclEntry::ActionList::iterator ial;
+    ial = al.begin();
+    EXPECT_EQ(1U, al.size());
+    EXPECT_EQ(SimpleAction::PASS, static_cast<SimpleAction *>(*ial.operator->())->GetAction());
+    AclEntrySandeshData data;
+    entry1.SetAclEntrySandeshData(data);
+    EXPECT_EQ(data.src_type, "network");
+    EXPECT_EQ(data.dst_type, "network");
+    EXPECT_EQ(data.dst_port_l.size(), 1);
+    EXPECT_EQ(data.dst_port_l.begin()->min, 10);
+    EXPECT_EQ(data.dst_port_l.begin()->max, 100);
+    EXPECT_EQ(data.src_port_l.begin()->min, 100);
+    EXPECT_EQ(data.src_port_l.begin()->max, 1000);
+    EXPECT_EQ(data.proto_l.size(), 1);
+    EXPECT_EQ(data.proto_l.begin()->min, 10);
+    EXPECT_EQ(data.proto_l.begin()->max, 10);
+    EXPECT_EQ(data.src, "network1");
+    EXPECT_EQ(data.dst, "network2");
+    EXPECT_EQ(data.ace_id, "1");
+}
+
+
+TEST_F(AclEntryTest, BasicIntrospecSgAclEntry) {
+    AclEntrySpec ae_spec1;
+    ae_spec1.id = 100;
+    ae_spec1.src_sg_id = 4;
+    ae_spec1.src_addr_type = AddressMatch::SG;
+
+    ae_spec1.dst_ip_addr = IpAddress::from_string("2.2.2.0");
+    ae_spec1.dst_ip_mask = IpAddress::from_string("255.255.255.0");
+    ae_spec1.dst_addr_type = AddressMatch::IP_ADDR; 
+
+    RangeSpec protocol;
+    protocol.min = 10;
+    protocol.max = 10;
+    ae_spec1.protocol.push_back(protocol);
+    RangeSpec src_port;
+    src_port.min = 100;
+    src_port.max = 1000;
+    ae_spec1.src_port.push_back(src_port);
+    RangeSpec dst_port;
+    dst_port.min = 10;
+    dst_port.max = 100;
+    ae_spec1.dst_port.push_back(dst_port);
+    ae_spec1.terminal = true;
+    ActionSpec action;
+    action.ta_type = TrafficAction::SIMPLE_ACTION;
+    action.simple_action = TrafficAction::PASS;
+    ae_spec1.action_l.push_back(action);
+
+    AclEntry entry1;
+    PacketHeader packet1;
+    SecurityGroupList src_sg_id_l;
+    src_sg_id_l.push_back(4);
+    packet1.src_sg_id_l = &src_sg_id_l;
+    packet1.dst_ip = 0x02020210;
+    packet1.protocol = 10;
+    packet1.dst_port = 99;
+    packet1.src_port  = 101;
+    entry1.PopulateAclEntry(ae_spec1);
+    AclEntry::ActionList al;
+    al = entry1.PacketMatch(packet1);
+    AclEntry::ActionList::iterator ial;
+    ial = al.begin();
+    EXPECT_EQ(1U, al.size());
+    EXPECT_EQ(SimpleAction::PASS, static_cast<SimpleAction *>(*ial.operator->())->GetAction());
+    AclEntrySandeshData data;
+    entry1.SetAclEntrySandeshData(data);
+    EXPECT_EQ(data.src_type, "sg");
+    EXPECT_EQ(data.dst_type, "ip");
+    EXPECT_EQ(data.dst_port_l.size(), 1);
+    EXPECT_EQ(data.dst_port_l.begin()->min, 10);
+    EXPECT_EQ(data.dst_port_l.begin()->max, 100);
+    EXPECT_EQ(data.src_port_l.begin()->min, 100);
+    EXPECT_EQ(data.src_port_l.begin()->max, 1000);
+    EXPECT_EQ(data.proto_l.size(), 1);
+    EXPECT_EQ(data.proto_l.begin()->min, 10);
+    EXPECT_EQ(data.proto_l.begin()->max, 10);
+    EXPECT_EQ(data.src, "4");
+    EXPECT_EQ(data.dst, "2.2.2.0 255.255.255.0");
+    EXPECT_EQ(data.ace_id, "100");
+}
+
 
 } // namespace
 

--- a/src/vnsw/agent/oper/agent.sandesh
+++ b/src/vnsw/agent/oper/agent.sandesh
@@ -386,6 +386,8 @@ struct AclEntrySandeshData {
     6: list <SandeshRange> dst_port_l;
     7: list <SandeshRange> proto_l;
     8: list <ActionStr> action_l;
+    9: string src_type;
+    10: string dst_type;
 }
 
 // ACL to Flow mapping Sandesh


### PR DESCRIPTION
- Add source and destination address types in the ACL entry introspection
- Web UI planning to use address type fields, during ACL entry display 
