### PR TITLE
Fix for #2345

### DIFF
--- a/src/opserver/test/utils/generator_fixture.py
+++ b/src/opserver/test/utils/generator_fixture.py
@@ -91,8 +91,8 @@ class GeneratorFixture(fixtures.Fixture):
         if ts:
             flow_object._timestamp = ts
         flow_object.send(sandesh=self._sandesh_instance)
+        flow.samples.append(flow_object)
     # end send_flow_stat
-
 
     def generate_flow_samples(self):
         self.flows = []
@@ -109,6 +109,7 @@ class GeneratorFixture(fixtures.Fixture):
                                            destip=0x0A0A0A02,
                                            sport=i + 10, dport=i + 100,
                                            protocol=i / 2))
+            self.flows[i].samples = []
             self._logger.info(str(self.flows[i]))
 
         # 'duration' - lifetime of the flow in seconds
@@ -156,7 +157,6 @@ class GeneratorFixture(fixtures.Fixture):
                 self.send_flow_stat(self.flows[cnt], bytes, pkts, ts)
             cnt += 1
     # end generate_flow_samples
-
 
     def send_vn_uve(self, vrouter, vn_id, num_vns):
         intervn_list = []

--- a/src/query_engine/select_fs_query.cc
+++ b/src/query_engine/select_fs_query.cc
@@ -230,7 +230,7 @@ void SelectQuery::fs_write_final_result_row(const uint64_t *t,
 inline uint64_t SelectQuery::fs_get_time_slice(const uint64_t& t) {
     AnalyticsQuery *mquery = (AnalyticsQuery*)main_query;
     uint64_t time_sample = (t - mquery->req_from_time)/granularity;
-    return mquery->req_from_time + ((time_sample+1) * granularity);
+    return mquery->req_from_time + (time_sample * granularity);
 }
 
 query_status_t SelectQuery::process_fs_query(


### PR DESCRIPTION
For FlowSeries queries when granularity is specified, time-sample starts @ start_time + granularity. Therefore, if granularity > (end_time - start_time), then time-sample is > end_time and hence no result is being returned. Modified code to start the time-sample @ start_time instead of start_time + granularity.
