### PR TITLE
Use monotonic_deadline_timer instead of deadline_timer.

### DIFF
--- a/src/ifmap/client/ifmap_channel.cc
+++ b/src/ifmap/client/ifmap_channel.cc
@@ -147,7 +147,7 @@ void IFMapChannel::set_connection_status(ConnectionStatus status) {
 
 // Will run in the context of the main task
 void IFMapChannel::CloseSockets(const boost::system::error_code& error,
-        boost::asio::deadline_timer *socket_close_timer) {
+        boost::asio::monotonic_deadline_timer *socket_close_timer) {
     // operation_aborted is the only possible error. Since we are not going to
     // cancel this timer, we should never really get an error.
     if (error) {
@@ -215,8 +215,8 @@ void IFMapChannel::ReconnectPreparationInMainThr() {
     // in the main task context.
     // Create the timer on the heap so that we release all resources correctly
     // even when we are called multiple times.
-    boost::asio::deadline_timer *socket_close_timer = 
-        new boost::asio::deadline_timer(*manager_->io_service());
+    boost::asio::monotonic_deadline_timer *socket_close_timer = 
+        new boost::asio::monotonic_deadline_timer(*manager_->io_service());
     socket_close_timer->expires_from_now(
         boost::posix_time::seconds(kSocketCloseTimeout), ec);
     socket_close_timer->async_wait(

--- a/src/ifmap/client/ifmap_channel.h
+++ b/src/ifmap/client/ifmap_channel.h
@@ -5,9 +5,9 @@
 #ifndef __IFMAP_CHANNEL_H__
 #define __IFMAP_CHANNEL_H__
 
-#include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/monotonic_deadline_timer.hpp>
 #include <boost/asio/strand.hpp>
 
 #ifdef __clang__
@@ -197,7 +197,7 @@ private:
     SslStream *GetSocket(ResponseState response_state);
     ProcCompleteMsgCb GetCallback(ResponseState response_state);
     void CloseSockets(const boost::system::error_code& error,
-                      boost::asio::deadline_timer *socket_close_timer);
+                     boost::asio::monotonic_deadline_timer *socket_close_timer);
     void SetArcSocketOptions();
     std::string timeout_to_string(uint64_t timeout);
     void set_connection_status(ConnectionStatus status);

--- a/src/ifmap/client/ifmap_state_machine.h
+++ b/src/ifmap/client/ifmap_state_machine.h
@@ -5,7 +5,7 @@
 #ifndef __IFMAP_STATE_MACHINE_H__
 #define __IFMAP_STATE_MACHINE_H__
 
-#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/monotonic_deadline_timer.hpp>
 #include <boost/statechart/state_machine.hpp>
 
 #include "base/queue_task.h"
@@ -136,11 +136,11 @@ private:
     }
 
     IFMapManager *manager_;
-    boost::asio::deadline_timer connect_timer_;
+    boost::asio::monotonic_deadline_timer connect_timer_;
     int ssrc_connect_attempts_;
     int arc_connect_attempts_;
     // used to limit the wait time for a response
-    boost::asio::deadline_timer response_timer_;
+    boost::asio::monotonic_deadline_timer response_timer_;
     // how many times we timed out waiting for a response
     int response_timer_expired_count_;
     WorkQueue<boost::intrusive_ptr<const sc::event_base> > work_queue_;

--- a/src/ifmap/client/test/ifmap_state_machine_test.cc
+++ b/src/ifmap/client/test/ifmap_state_machine_test.cc
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "base/logging.h"
+#include "base/task_annotations.h"
 #include "base/test/task_test_util.h"
 #include "db/db.h"
 #include "db/db_graph.h"
@@ -103,7 +104,7 @@ protected:
 
     void EventWait(int timeout) {
         bool is_expired = false;
-        boost::asio::deadline_timer timer(*(evm_.io_service()));
+        boost::asio::monotonic_deadline_timer timer(*(evm_.io_service()));
         timer.expires_from_now(boost::posix_time::seconds(timeout));
         timer.async_wait(boost::bind(&IFMapStateMachineTest::on_timeout,
                          boost::asio::placeholders::error, &is_expired));
@@ -1208,6 +1209,7 @@ INSTANTIATE_TEST_CASE_P(ConnReset2, IFMapStateMachineConnResetTest2,
                       IFMapStateMachineTest::CONNECT_TIMER_WAIT));
 
 int main(int argc, char **argv) {
+    ConcurrencyChecker::disable_ = true;
     LoggingInit();
     ::testing::InitGoogleMock(&argc, argv);
     bool success = RUN_ALL_TESTS();

--- a/src/ifmap/test/ifmap_xmpp_test.cc
+++ b/src/ifmap/test/ifmap_xmpp_test.cc
@@ -430,7 +430,7 @@ protected:
             return;
         }
         bool is_expired = false;
-        boost::asio::deadline_timer timer(*evm_.io_service());
+        boost::asio::monotonic_deadline_timer timer(*evm_.io_service());
         timer.expires_from_now(boost::posix_time::seconds(timeout));
         timer.async_wait(boost::bind(&XmppIfmapTest::on_timeout, 
                          boost::asio::placeholders::error, &is_expired));


### PR DESCRIPTION
Also, disable concurrency checks in ifmap_state_machine_test.
