### PR TITLE
Fix for #2293 - vrouter UVE's generated by collector not deleted after hostname change

### DIFF
--- a/src/analytics/delrequest.lua
+++ b/src/analytics/delrequest.lua
@@ -34,7 +34,7 @@ for k,v in pairs(typ) do
         local delseq = lres[iter+1]
         local st,en
         st,en = string.find(deluve,":")
-        local deltbl = string.sub(deluve, st-1)
+        local deltbl = string.sub(deluve, 1, st-1)
 
         local dkey = "DEL:"..deluve..":"..sm..":"..deltyp..":"..delseq
         redis.log(redis.LOG_NOTICE,"DEL for "..dkey)

--- a/src/analytics/generator.cc
+++ b/src/analytics/generator.cc
@@ -262,8 +262,10 @@ void SandeshGenerator::DisconnectSession(VizSession *vsession) {
         state_machine_ = NULL;
         collector_->GetOSP()->DeleteUVEs(source_, module_, 
                                          node_type_, instance_id_);
+        // Delete the ModuleServerState UVE on generator disconnect
         ModuleServerState ginfo;
-        GetGeneratorInfo(ginfo);
+        ginfo.set_name(name_);
+        ginfo.set_deleted(true);
         SandeshModuleServerTrace::Send(ginfo);
     } else {
         GENERATOR_LOG(ERROR, "Disconnect for session:" << vsession->ToString() <<

--- a/src/opserver/test/analytics_systest.py
+++ b/src/opserver/test/analytics_systest.py
@@ -449,6 +449,30 @@ class AnalyticsTest(testtools.TestCase, fixtures.TestWithFixtures):
                                                         exp_mod_list)
     #end test_09_table_source_module_list 
 
+    #@unittest.skip('verify generator addition and deletion')
+    def test_10_add_delete_generator(self):
+        '''
+        This test verifies the existence of the generator UVE
+        upon generator add/delete.
+        '''
+        logging.info('*** test_10_add_delete_generator ***')
+        if AnalyticsTest._check_skip_test() is True:
+            return True
+
+        vizd_obj = self.useFixture(
+            AnalyticsFixture(logging,
+                             builddir, 0))
+        assert vizd_obj.verify_on_setup()
+        # verify that QueryEngine is present in the generator UVE list
+        generator_id = socket.gethostname()+':'+'Analytics'+':'+ \
+            'QueryEngine'+':'+'0' 
+        assert vizd_obj.verify_generator_uve(generator_id)
+        # stop the QueryEngine and verify that it is not present in the
+        # generator UVE list
+        vizd_obj.query_engine.stop()
+        assert vizd_obj.verify_generator_uve(generator_id, False)
+    # end test_10_add_delete_generator
+
     @staticmethod
     def get_free_port():
         cs = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/src/opserver/test/utils/analytics_fixture.py
+++ b/src/opserver/test/utils/analytics_fixture.py
@@ -405,6 +405,22 @@ class AnalyticsFixture(fixtures.Fixture):
             return False
         return True
 
+    @retry(delay=1, tries=5)
+    def verify_generator_uve(self, generator_id, exist=True):
+        self.logger.info('verify_generator_uve')
+        vns = VerificationOpsSrv('127.0.0.1', self.opserver_port)
+        # get generator list
+        gen_list = vns.uve_query('generators')
+        try:
+            self.logger.info('generators: %s' % str(gen_list))
+            for gen in gen_list:
+                if gen['name'] == generator_id:
+                    return exist
+        except Exception as e:
+            self.logger.error('Exception: %s' % e)
+        return not exist
+    # end verify_generator_uve
+
     @retry(delay=1, tries=6)
     def verify_message_table_messagetype(self):
         self.logger.info("verify_message_table_messagetype")

--- a/src/opserver/test/utils/opserver_introspect_utils.py
+++ b/src/opserver/test/utils/opserver_introspect_utils.py
@@ -56,6 +56,9 @@ class VerificationOpsSrv (VerificationUtilBase):
         return self.dict_get('analytics/table/%s/column-values/%s' \
                              % (table, col_name)) 
 
+    def uve_query(self, query):
+        return self.dict_get('analytics/uves/%s' % query)
+
     def post_query_json(self, json_str, sync=True):
         '''
         this module is to support raw query given in json format


### PR DESCRIPTION
When a generator node is deleted, only the UVEs originated by the generator are removed. The UVE originated by the Collector (ModuleServerState) with the <host-name>:<module-name> of the generator as the key is not removed and hence it shows up in the generator list (/uves/generators). Fixed an issue with the extraction of table name in delrequest.lua, because of which the keys are not removed from the table.
