### PR TITLE
Fix for #2293

### DIFF
--- a/src/analytics/delrequest.lua
+++ b/src/analytics/delrequest.lua
@@ -34,7 +34,7 @@ for k,v in pairs(typ) do
         local delseq = lres[iter+1]
         local st,en
         st,en = string.find(deluve,":")
-        local deltbl = string.sub(deluve, st-1)
+        local deltbl = string.sub(deluve, 1, st-1)
 
         local dkey = "DEL:"..deluve..":"..sm..":"..deltyp..":"..delseq
         redis.log(redis.LOG_NOTICE,"DEL for "..dkey)


### PR DESCRIPTION
Fixed an issue with the extraction of table name in delrequest.lua, because of which the UVE keys are not removed from the table in redis-uve.
