### PR TITLE
Do not modify TcpSession::name_ unnecessarily during session closure

### DIFF
--- a/src/io/tcp_session.cc
+++ b/src/io/tcp_session.cc
@@ -213,7 +213,6 @@ void TcpSession::CloseInternal(bool callObserver) {
         return;
     }
     established_ = false;
-    name_ = "-";
 
     // Take a reference through intrusive pointer to protect session from
     // possibly getting deleted from another thread.


### PR DESCRIPTION
Do not modify name_ when session goes down. Other threads can potentially read the same via ToString() at the same time
