### PR TITLE
xen: Added support to build agent in xen builder

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -6,6 +6,7 @@
 # src directory
 
 import sys
+import platform
 
 subdirs = [
            'analytics',
@@ -52,7 +53,9 @@ common.Append(LIBPATH = libpath)
 common.Prepend(LIBS = libs)
 common.Append(CCFLAGS = '-Wall -Werror -Wsign-compare')
 if not sys.platform.startswith('darwin'):
-    common.Append(CCFLAGS = ['-Wno-unused-local-typedefs'])
+    if platform.system().startswith('Linux'):
+       if not platform.linux_distribution()[0].startswith('XenServer'):
+          common.Append(CCFLAGS = ['-Wno-unused-local-typedefs'])
 common.Append(CPPPATH = include)
 
 BuildEnv = common.Clone()

--- a/src/base/misc_utils.cc
+++ b/src/base/misc_utils.cc
@@ -120,25 +120,8 @@ bool MiscUtils::GetBuildInfo(BuildModule id, const string &build_info,
     string build_num;
 
     bool ret = GetContrailVersionInfo(id, rpm_version, build_num);
-    rapidjson::Document d;
-    if (d.Parse<0>(const_cast<char *>(build_info.c_str())).HasParseError()) {
-        result = build_info;
-        return false;
-    }
-    rapidjson::Value& fields = d["build-info"];
-    if (!fields.IsArray()) {
-        result = build_info;
-        return false;
-    }
-    fields[0u].AddMember("build-id", const_cast<char *>(rpm_version.c_str()), 
-                         d.GetAllocator());
-    fields[0u].AddMember("build-number", const_cast<char *>(build_num.c_str()), 
-                         d.GetAllocator());
 
-    rapidjson::StringBuffer strbuf;
-    rapidjson::Writer<rapidjson::StringBuffer> writer(strbuf);
-    d.Accept(writer);
-    result = strbuf.GetString();
+    result = (build_info + "\"build-id\" : \"" + rpm_version + "\", \"build-number\" : \"" + build_num  + "\"}]}");
     return ret;
 }
 

--- a/src/vnsw/agent/init/agent_param.cc
+++ b/src/vnsw/agent/init/agent_param.cc
@@ -499,3 +499,6 @@ AgentParam::AgentParam() :
     vgw_config_table_ = std::auto_ptr<VirtualGatewayConfigTable>
         (new VirtualGatewayConfigTable());
 }
+
+AgentParam::~AgentParam() {
+}

--- a/src/vnsw/agent/init/agent_param.h
+++ b/src/vnsw/agent/init/agent_param.h
@@ -34,7 +34,7 @@ public:
     };
 
     AgentParam();
-    virtual ~AgentParam() {}
+    virtual ~AgentParam();
 
     bool IsVHostConfigured() {
         return vhost_.addr_.to_ulong() != 0? true : false;

--- a/src/vnsw/agent/services/metadata_proxy.cc
+++ b/src/vnsw/agent/services/metadata_proxy.cc
@@ -321,7 +321,7 @@ MetadataProxy::ErrorClose(HttpSession *session) {
     snprintf(response, sizeof(response),
              "HTTP/1.1 404 Not Found\n"
              "Content-Type: text/html; charset=UTF-8\n"
-             "Content-Length: %lu\n"
+             "Content-Length: %u\n"
              "\n%s", strlen(body), body);
     session->Send(reinterpret_cast<const u_int8_t *>(response),
                   strlen(response), NULL);

--- a/src/vnsw/agent/uve/vrouter_uve_entry.cc
+++ b/src/vnsw/agent/uve/vrouter_uve_entry.cc
@@ -747,7 +747,7 @@ uint8_t VrouterUveEntry::CalculateBandwitdh(uint64_t bytes, int speed_mbps,
     }
     uint64_t speed_bps = speed_mbps * 1024 * 1024;
     uint64_t bps = bits/diff_seconds;
-    return (double)bps/speed_bps * 100;
+    return bps/speed_bps * 100;
 }
 
 uint8_t VrouterUveEntry::GetBandwidthUsage

--- a/src/vnsw/agent/vgw/test/test_vgw.cc
+++ b/src/vnsw/agent/vgw/test/test_vgw.cc
@@ -55,7 +55,7 @@ TEST_F(VgwTest, conf_file_1) {
 
     EXPECT_STREQ(it->vrf().c_str(), "default-domain:admin:public1:public1");
     EXPECT_STREQ(it->interface().c_str(), "vgw1");
-    EXPECT_EQ(it->subnets().size(), 2);
+    EXPECT_EQ(it->subnets().size(), (unsigned int) 2);
     if (it->routes().size() == 2) {
         subnet = it->subnets()[0];
         EXPECT_STREQ(subnet.ip_.to_string().c_str(), "2.2.1.0");
@@ -66,7 +66,7 @@ TEST_F(VgwTest, conf_file_1) {
         EXPECT_EQ(subnet.plen_, 24);
     }
 
-    EXPECT_EQ(it->routes().size(), 2);
+    EXPECT_EQ(it->routes().size(), (unsigned int) 2);
     if (it->routes().size() == 2) {
         subnet = it->routes()[0];
         EXPECT_STREQ(subnet.ip_.to_string().c_str(), "10.10.10.1");


### PR DESCRIPTION
- Added platform detection setting to selectively turn off Wno-unused-local-typedefs
  for gcc 4.1.2
- Reverted changed in GetBuildInfo() as GCC 4.1.2 complained with warning,
  'type always evaluates to true'
- Fix in agent_param.cc, ~AgentParam() [Praveen]
- Fix in return data type CalculateBandwidth() - Fix in data type comparison in test_vgw.cc

Signed-off-by: Anirban Chakraborty abchak@juniper.net
