### PR TITLE
In cdbq dequeue callback accumulate the mutations to be written

### DIFF
--- a/src/gendb/cdb_if.h
+++ b/src/gendb/cdb_if.h
@@ -177,6 +177,7 @@ class CdbIf : public GenDbIf {
         bool ColListFromColumnOrSuper(GenDb::ColList&, std::vector<org::apache::cassandra::ColumnOrSuperColumn>&, const string&);
 
         bool Db_AsyncAddColumn(CdbIfColList &cl);
+        void Db_BatchAddColumn(bool done);
         bool Db_Columnfamily_present(const std::string& cfname);
         bool Db_GetColumnfamily(CdbIfCfInfo **info, const std::string& cfname);
         bool Db_IsInitDone() const;
@@ -233,6 +234,10 @@ class CdbIf : public GenDbIf {
         CleanupTask *cleanup_;
 
         int cassandra_ttl_;
+        typedef std::vector<Mutation> MutationList;
+        typedef std::map<std::string, MutationList> CFMutationMap;
+        typedef std::map<std::string, CFMutationMap> CassandraMutationMap;
+        CassandraMutationMap mutation_map_;
 };
 
 #endif


### PR DESCRIPTION
to cassandra in mutation map and then do batch write to cassandra
from cdbq task exit callback. This improves cdbq cassandra write
performance since we are bunching kMaxIterations write. Cdbq can
now handle database writes corresponding to 1.5K sandesh messages/sec.
