### PR TITLE
Changes to download config even if we do not have any VM-subscribes.

### DIFF
--- a/src/ifmap/ifmap_server.cc
+++ b/src/ifmap/ifmap_server.cc
@@ -236,6 +236,7 @@ void IFMapServer::ClientUnregister(IFMapClient *client) {
 bool IFMapServer::ProcessClientWork(bool add, IFMapClient *client) {
     if (add) {
         ClientRegister(client);
+        ClientGraphDownload(client);
     } else {
         ClientGraphCleanup(client);
         RemoveSelfAddedLinksAndObjects(client);

--- a/src/ifmap/testdata/vr_gsc_config.xml
+++ b/src/ifmap/testdata/vr_gsc_config.xml
@@ -1,0 +1,39 @@
+<ns3:Envelope xmlns:ns2="http://www.trustedcomputinggroup.org/2010/IFMAP/2" xmlns:ns3="http://www.w3.org/2003/05/soap-envelope">
+  <ns3:Body>
+    <ns2:response>
+      <pollResult>
+        <updateResult name="root">
+          <resultItem>
+            <identity other-type-definition="extended" type="other" name="contrail:virtual-router:vr1"/>
+            <identity other-type-definition="extended" type="other" name="contrail:global-system-config:gsc1"/>
+            <metadata>
+              <contrail:global-system-config-virtual-router xmlns:contrail="http://www.contrailsystems.com/vnc_cfg.xsd" ifmap-cardinality="singleValue" ifmap-publisher-id="test--1870931913-1" ifmap-timestamp="2012-11-03T20:33:33+00:00"/>
+            </metadata>
+          </resultItem>
+          <resultItem>
+              <identity name="contrail:global-system-config:gsc1" type="other" other-type-definition="extended" />
+                  <metadata>
+                          <contrail:id-perms xmlns:contrail="http://www.contrailsystems.com/vnc_cfg.xsd" ifmap-cardinality="singleValue" ifmap-publisher-id="api-server-1--0000000001-1" ifmap-timestamp="2013-03-11T02:43:43-07:00">
+                                  <uuid>
+                                          <uuid-mslong>1079667397199020369</uuid-mslong>
+                                          <uuid-lslong>11783474986262425118</uuid-lslong>
+                                  </uuid>
+                          </contrail:id-perms>
+                  </metadata>
+          </resultItem>
+          <resultItem>
+              <identity name="contrail:virtual-router:vr1" type="other" other-type-definition="extended" />
+                  <metadata>
+                          <contrail:id-perms xmlns:contrail="http://www.contrailsystems.com/vnc_cfg.xsd" ifmap-cardinality="singleValue" ifmap-publisher-id="api-server-1--0000000001-1" ifmap-timestamp="2013-03-11T02:43:43-07:00">
+                                  <uuid>
+                                          <uuid-mslong>1079667397199020368</uuid-mslong>
+                                          <uuid-lslong>11783474986262425117</uuid-lslong>
+                                  </uuid>
+                          </contrail:id-perms>
+                  </metadata>
+          </resultItem>
+        </updateResult>
+      </pollResult>
+    </ns2:response>
+  </ns3:Body>
+</ns3:Envelope>

--- a/src/ifmap/testdata/vr_gsc_config_no_prop.xml
+++ b/src/ifmap/testdata/vr_gsc_config_no_prop.xml
@@ -1,0 +1,17 @@
+<ns3:Envelope xmlns:ns2="http://www.trustedcomputinggroup.org/2010/IFMAP/2" xmlns:ns3="http://www.w3.org/2003/05/soap-envelope">
+  <ns3:Body>
+    <ns2:response>
+      <pollResult>
+        <updateResult name="root">
+          <resultItem>
+            <identity other-type-definition="extended" type="other" name="contrail:virtual-router:vr1"/>
+            <identity other-type-definition="extended" type="other" name="contrail:global-system-config:gsc1"/>
+            <metadata>
+              <contrail:global-system-config-virtual-router xmlns:contrail="http://www.contrailsystems.com/vnc_cfg.xsd" ifmap-cardinality="singleValue" ifmap-publisher-id="test--1870931913-1" ifmap-timestamp="2012-11-03T20:33:33+00:00"/>
+            </metadata>
+          </resultItem>
+        </updateResult>
+      </pollResult>
+    </ns2:response>
+  </ns3:Body>
+</ns3:Envelope>


### PR DESCRIPTION
Today the problem only occurs if we receive config before the VR-subscribe
although Config will get downloaded if we receive VR-sub before the config.
Fixing so that config is downloaded in both cases even if we do not have any
VM-reg.
