### PR TITLE
Configuration format changes for some of the contrail software daemons

### DIFF
--- a/src/base/contrail_ports.h
+++ b/src/base/contrail_ports.h
@@ -7,6 +7,7 @@
 
 class ContrailPorts {
 public:
+    static const short ControlBgp = 179;
     static const short ControlXmpp = 5269;
     static const short DiscoveryServerPort = 5998;
     static const short RedisQueryPort = 6380;
@@ -30,6 +31,8 @@ public:
     static const short DnsRndc = 8094;
     static const short ApiServerOpen = 8095;
     static const short AnalyzerUdpPort = 8099;
+    static const short SyslogPort = 514;
+    static const short IfmapServerPort = 8443;
 
     // following ports are reserved for supervisord usage
     static const short supervisord_analytics = 9002;

--- a/src/base/util.h
+++ b/src/base/util.h
@@ -6,9 +6,13 @@
 #define __UTIL_H__
 
 #include <boost/algorithm/string.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/ip/host_name.hpp>
+#include <boost/asio/ip/tcp.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/function.hpp>
+#include <boost/program_options.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/nil_generator.hpp>
@@ -38,7 +42,6 @@
         assert(Cond);           \
     } while (0)
 #endif
-
 
 template <typename IntType>
 bool BitIsSet(IntType value, size_t bit) {
@@ -197,6 +200,34 @@ static inline boost::asio::ip::address_v4 GetIp4SubnetBroadcastAddress(
     boost::asio::ip::address_v4 subnet(ip_prefix.to_ulong() | 
                                        ~(0xFFFFFFFF << (32 - plen)));
     return subnet;
+}
+
+static inline std::string GetHostIp(boost::asio::io_service *io_service,
+                                    std::string hostname) {
+    boost::asio::ip::tcp::resolver::iterator iter;
+    boost::system::error_code error;
+    boost::asio::ip::tcp::resolver resolver(*io_service);
+    boost::asio::ip::tcp::resolver::query query(hostname, "");
+
+    iter = resolver.resolve(query, error);
+
+    return iter->endpoint().address().to_string();
+}
+
+template <typename ValueType>
+static inline void GetOptValue(const boost::program_options::variables_map &var_map,
+                               ValueType &var, std::string val,
+                               ValueType emptyValue) {
+
+    // Check of the value is present.
+    if (var_map.count(val)) {
+        ValueType opt_val = var_map[val].as<ValueType>();
+
+        // Assign the value, if it is not equal to None equivalent.
+        if (opt_val != emptyValue) {
+            var = var_map[val].as<ValueType>();
+        }
+    }
 }
 
 // Writes a number into a string

--- a/src/control-node/main.cc
+++ b/src/control-node/main.cc
@@ -80,7 +80,7 @@ static void WaitForIdle() {
             break;
         }
         usleep(1000);
-    }    
+    }
 }
 
 static void ShutdownDiscoveryClient(DiscoveryServiceClient *client) {
@@ -144,25 +144,25 @@ bool ControlNodeVersion(string &build_info_str) {
     return MiscUtils::GetBuildInfo(MiscUtils::ControlNode, BuildInfo, build_info_str);
 }
 
-static void FillProtoStats(IPeerDebugStats::ProtoStats &stats, 
+static void FillProtoStats(IPeerDebugStats::ProtoStats &stats,
                            PeerProtoStats &proto_stats) {
     proto_stats.open = stats.open;
     proto_stats.keepalive = stats.keepalive;
     proto_stats.close = stats.close;
     proto_stats.update = stats.update;
     proto_stats.notification = stats.notification;
-    proto_stats.total = stats.open + stats.keepalive + stats.close + 
+    proto_stats.total = stats.open + stats.keepalive + stats.close +
         stats.update + stats.notification;
 }
 
-static void FillRouteUpdateStats(IPeerDebugStats::UpdateStats &stats, 
+static void FillRouteUpdateStats(IPeerDebugStats::UpdateStats &stats,
                                  PeerUpdateStats &rt_stats) {
     rt_stats.total = stats.total;
     rt_stats.reach = stats.reach;
     rt_stats.unreach = stats.unreach;
 }
 
-static void FillPeerDebugStats(IPeerDebugStats *peer_state, 
+static void FillPeerDebugStats(IPeerDebugStats *peer_state,
                           PeerStatsInfo &stats) {
     PeerProtoStats proto_stats_tx;
     PeerProtoStats proto_stats_rx;
@@ -211,9 +211,9 @@ void FillBgpPeerStats(BgpServer *server, BgpPeer *peer) {
     BGPPeerInfo::Send(peer_info);
 }
 
-void LogControlNodePeerStats(BgpServer *server, 
+void LogControlNodePeerStats(BgpServer *server,
                              BgpXmppChannelManager *xmpp_channel_mgr) {
-    xmpp_channel_mgr->VisitChannels(boost::bind(FillXmppPeerStats, 
+    xmpp_channel_mgr->VisitChannels(boost::bind(FillXmppPeerStats,
                                                 server, _1));
     server->VisitBgpPeers(boost::bind(FillBgpPeerStats, server, _1));
 }
@@ -338,7 +338,7 @@ bool ControlNodeInfoLogger(BgpSandeshContext &ctx) {
         change = true;
     }
 
-    if (change) 
+    if (change)
         BGPRouterInfo::Send(state);
 
     if (first) first = false;
@@ -351,8 +351,8 @@ bool ControlNodeInfoLogger(BgpSandeshContext &ctx) {
 
 // Trigger graceful shutdown of control-node process.
 //
-// IO (evm) is shutdown first. Afterwards, main() resumes, shutting down rest of the
-// objects, and eventually exit()s.
+// IO (evm) is shutdown first. Afterwards, main() resumes, shutting down rest
+// of the objects, and eventually exit()s.
 void ControlNodeShutdown() {
     static bool shutdown_;
 
@@ -363,128 +363,130 @@ void ControlNodeShutdown() {
     evm.Shutdown();
 }
 
-// Read command line options from a file for ease of use. These options read
-// from file are appended to those specified in the command line.
-int ReadCommandLineOptionsFromFile(int argc, char **argv,
-                                   std::vector<string> &tokens, string &line,
-                                   char **p_argv, size_t p_argv_size) {
-    int p_argc = argc;
-
-    // Copy command line options
-    for (int i = 0; i < argc; i++) {
-        p_argv[i] = argv[i];
-    }
-
-    for (int j = 0; j < argc; j++) {
-
-        // Check for --options-file option
-        if (!boost::iequals("--options-file", argv[j])) continue;
-
-        // Make sure there is a file name specified.
-        if ((j + 1) >= argc) break;
-
-        // Read text from the file and split into different tokens.
-        line = FileRead(argv[j + 1]);
-        boost::split(tokens, line, boost::is_any_of(" \n\t"));
-        for (size_t k = 0; k < tokens.size(); k++) {
-
-            // Ignore empty strings.
-            if (tokens[k].empty()) continue;
-
-            // Make sure that there is enough room in the output vector.
-            assert((size_t) p_argc < p_argv_size);
-
-            // Retrieve char * token into output vector.
-            p_argv[p_argc++] = const_cast<char *>(tokens[k].c_str());
-        }
-        break;
-    }
-
-    // Return the updated number of command line options to use.
-    return p_argc;
-}
-
-int main(int argc, char *argv[]) {
-    bool enable_local_logging = false;
-    bool disable_logging = false;
-    bool test_mode = false;
+static int control_node_main(int argc, char *argv[]) {
     boost::system::error_code error;
+
+    // Specify defaults for all options possible.
+    uint16_t bgp_port = ContrailPorts::ControlBgp;
+    string collector_server;
+    uint16_t collector_port = ContrailPorts::CollectorPort;
+    string bgp_config_file = "bgp_config.xml";
+    string discovery_server;
+    uint16_t discovery_port = ContrailPorts::DiscoveryServerPort;
     string hostname(host_name(error));
-    const string default_log_file = "<stdout>";
-    const unsigned long default_log_file_size = 10*1024*1024; // 10MB
-    const unsigned int default_log_file_index = 10;
-    opt::options_description desc("Command line options");
-    desc.add_options()
-        ("bgp-port",
-         opt::value<int>()->default_value(BgpConfigManager::kDefaultPort),
-         "BGP listener port")
-        ("collector", opt::value<string>(),
-            "IP address of sandesh collector")
-        ("collector-port", opt::value<int>(),
-            "Port of sandesh collector")
-        ("config-file", opt::value<string>()->default_value("bgp_config.xml"),
-            "Configuration file")
-        ("discovery-server", opt::value<string>(),
-            "IP address of Discovery Server")
-        ("discovery-port", 
-            opt::value<int>()->default_value(ContrailPorts::DiscoveryServerPort),
-            "Port of Discovery Server")
-        ("help", "help message")
-        ("hostname", opt::value<string>()->default_value(hostname),
-            "Hostname of control-node")
-        ("host-ip", opt::value<string>(), "IP address of control-node")
-        ("http-server-port",
-            opt::value<int>()->default_value(ContrailPorts::HttpPortControl),
-            "Sandesh HTTP listener port")
-        ("log-category", opt::value<string>()->default_value(""),
-            "Category filter for local logging of sandesh messages")
-        ("log-disable", opt::bool_switch(&disable_logging),
-             "Disable sandesh logging")
-        ("log-file", opt::value<string>()->default_value(default_log_file),
-             "Filename for the logs to be written to")
-        ("log-file-index",
-             opt::value<unsigned int>()->default_value(default_log_file_index),
-             "Maximum log file roll over index")
-        ("log-file-size",
-             opt::value<unsigned long>()->default_value(default_log_file_size),
-             "Maximum size of the log file")
-        ("log-level", opt::value<string>()->default_value("SYS_NOTICE"),
-            "Severity level for local logging of sandesh messages")
-        ("log-local", opt::bool_switch(&enable_local_logging),
-             "Enable local logging of sandesh messages")
-        ("map-password", opt::value<string>(), "MAP server password")
-        ("map-server-url", opt::value<string>(), "MAP server URL")
-        ("map-user", opt::value<string>(), "MAP server username")
-        ("options-file", opt::value<string>(), "Command line options file")
-        ("use-certs", opt::value<string>(),
-            "Certificates store to use for communication with MAP server")
-        ("xmpp-port",
-            opt::value<int>()->default_value(ContrailPorts::ControlXmpp),
-            "XMPP listener port")
+    string host_ip = GetHostIp(evm.io_service(), hostname);
+    uint16_t http_server_port = ContrailPorts::HttpPortControl;
+    string log_category = "";
+    bool disable_logging = false;
+    string log_file = "<stdout>";
+    int log_file_index = 10;
+    long log_file_size = 10*1024*1024; // 10MB
+    string log_level = "SYS_NOTICE";
+    bool enable_local_logging = false;
+    string ifmap_server_url;
+    string ifmap_password = "control-user-passwd";
+    string ifmap_user = "control-user";
+    string certs_store = "";
+    uint16_t xmpp_port = ContrailPorts::ControlXmpp;
+    string config_file = "/etc/contrail/control-node.conf";
+    bool test_mode = false;
+
+    // Command line only options.
+    opt::options_description generic("Generic options");
+    generic.add_options()
+        ("conf-file", opt::value<string>()->default_value(config_file),
+             "Configuration file")
+         ("help", "help message")
         ("version", "Display version information")
-        ("use-certs", opt::value<string>(),
-            "Use certificates to communicate with MAP server; Specify certificate store")
-        ("test-mode", opt::bool_switch(&test_mode),
+    ;
+
+    // Command line and config file options.
+    opt::options_description config("Configuration options");
+    config.add_options()
+        ("BGP.config-file",
+             opt::value<string>()->default_value(bgp_config_file),
+             "BGP Configuration file")
+        ("BGP.port", opt::value<uint16_t>()->default_value(bgp_port),
+             "BGP listener port")
+
+        ("COLLECTOR.port",
+             opt::value<uint16_t>()->default_value(collector_port),
+             "Port of sandesh collector")
+        ("COLLECTOR.server",
+             opt::value<string>()->default_value(collector_server),
+             "IP address of sandesh collector")
+
+        ("DEFAULTS.hostip", opt::value<string>(), "IP address of control-node")
+        ("DEFAULTS.hostname", opt::value<string>()->default_value(hostname),
+             "Hostname of control-node")
+        ("DEFAULTS.http-server-port",
+             opt::value<uint16_t>()->default_value(http_server_port),
+             "Sandesh HTTP listener port")
+        ("DEFAULTS.test-mode", opt::bool_switch(&test_mode),
              "Enable running of daemon in test-mode")
+        ("DEFAULTS.xmpp-server-port",
+            opt::value<uint16_t>()->default_value(xmpp_port), "XMPP listener port")
+
+        ("DISCOVERY.port", opt::value<uint16_t>()->default_value(discovery_port),
+            "Port of Discovery Server")
+        ("DISCOVERY.server",
+             opt::value<string>()->default_value(discovery_server),
+             "IP address of Discovery Server")
+
+        ("IFMAP.password", opt::value<string>()->default_value(ifmap_password),
+             "IFMAP server password")
+        ("IFMAP.server-url",
+             opt::value<string>()->default_value(ifmap_server_url),
+             "IFMAP server URL")
+        ("IFMAP.user", opt::value<string>()->default_value(ifmap_user),
+
+             "IFMAP server username")
+        ("IFMAP.certs-store", opt::value<string>()->default_value(certs_store),
+             "Certificates store to use for communication with IFMAP server")
+
+        ("LOG.category", opt::value<string>()->default_value(log_category),
+             "Category filter for local logging of sandesh messages")
+        ("LOG.disable", opt::bool_switch(&disable_logging),
+             "Disable sandesh logging")
+        ("LOG.file", opt::value<string>()->default_value(log_file),
+             "Filename for the logs to be written to")
+        ("LOG.file-index",
+             opt::value<int>()->default_value(log_file_index),
+             "Maximum log file roll over index")
+        ("LOG.file-size",
+             opt::value<long>()->default_value(log_file_size),
+             "Maximum size of the log file")
+        ("LOG.level", opt::value<string>()->default_value(log_level),
+             "Severity level for local logging of sandesh messages")
+        ("LOG.local", opt::bool_switch(&enable_local_logging),
+             "Enable local logging of sandesh messages")
         ;
 
-    std::vector<string> tokens;
+    opt::options_description config_file_options;
+    config_file_options.add(config);
+    opt::options_description cmdline_options("Allowed options");
+    cmdline_options.add(generic).add(config);
+    vector<string> tokens;
     string line;
-    char *p_argv[argc + 128];
-    int p_argc;
-
-    // Optionally, retrieve command line options from a file.
-    p_argc = ReadCommandLineOptionsFromFile(argc, argv, tokens, line, p_argv,
-                                            sizeof(p_argv)/sizeof(p_argv[0]));
-
-    // Process collective options those specified in the command line and those
-    // in the file (optionl).
     opt::variables_map var_map;
-    opt::store(opt::parse_command_line(p_argc, p_argv, desc), var_map);
+
+    // Process options off command line first.
+    opt::store(opt::parse_command_line(argc, argv, cmdline_options), var_map);
+
+    // Process options off configuration file.
+    GetOptValue<string>(var_map, config_file, "conf-file", "");
+    ifstream config_file_in;
+    config_file_in.open(config_file.c_str());
+    if (config_file_in.good()) {
+        opt::store(opt::parse_config_file(config_file_in, config_file_options),
+                   var_map);
+    }
+    config_file_in.close();
+
     opt::notify(var_map);
 
     if (var_map.count("help")) {
-        cout << desc << endl;
+        cout << cmdline_options << endl;
         exit(0);
     }
 
@@ -495,26 +497,43 @@ int main(int argc, char *argv[]) {
         exit(0);
     }
 
+    GetOptValue<string>(var_map, bgp_config_file, "BGP.config-file", "");
+    GetOptValue<uint16_t>(var_map, bgp_port, "BGP.port", 0);
+    GetOptValue<uint16_t>(var_map, collector_port, "COLLECTOR.port", 0);
+    GetOptValue<string>(var_map, collector_server, "COLLECTOR.server", "");
+
+    GetOptValue<string>(var_map, host_ip, "DEFAULTS.hostip", "");
+    GetOptValue<string>(var_map, hostname, "DEFAULTS.hostname", "");
+
+    GetOptValue<uint16_t>(var_map, http_server_port, "DEFAULTS.http-server-port", 0);
+    GetOptValue<uint16_t>(var_map, xmpp_port, "DEFAULTS.xmpp-server-port", 0);
+
+    GetOptValue<uint16_t>(var_map, discovery_port, "DISCOVERY.port", 0);
+    GetOptValue<string>(var_map, discovery_server, "DISCOVERY.server", "");
+
+
+    GetOptValue<string>(var_map, log_category, "LOG.category", "");
+    GetOptValue<string>(var_map, log_file, "LOG.file", "");
+    GetOptValue<int>(var_map, log_file_index, "LOG.file-index", 0);
+    GetOptValue<long>(var_map, log_file_size, "LOG.file-size", 0);
+    GetOptValue<string>(var_map, log_level, "LOG.level", "");
+
+    GetOptValue<string>(var_map, ifmap_password, "IFMAP.password", "");
+    GetOptValue<string>(var_map, ifmap_server_url, "IFMAP.server-url", "");
+    GetOptValue<string>(var_map, ifmap_user, "IFMAP.user", "");
+    GetOptValue<string>(var_map, certs_store, "IFMAP.certs-store", "");
+
     ControlNode::SetProgramName(argv[0]);
-    unsigned long log_file_size = default_log_file_size;
-    unsigned long log_file_index = default_log_file_index;
-    if (var_map.count("log-file-size")) {
-        log_file_size = var_map["log-file-size"].as<unsigned long>();
-    }
-    if (var_map.count("log-file-index")) {
-        log_file_index = var_map["log-file-index"].as<unsigned int>();
-    }
-    if (var_map["log-file"].as<string>() == default_log_file) {
+    if (log_file == "<stdout>") {
         LoggingInit();
     } else {
-        LoggingInit(var_map["log-file"].as<string>(), log_file_size,
-                    log_file_index);
+        LoggingInit(log_file, log_file_size, log_file_index);
     }
     TaskScheduler::Initialize();
     ControlNode::SetDefaultSchedulingPolicy();
     BgpSandeshContext sandesh_context;
 
-    if (!var_map.count("discovery-server")) {
+    if (discovery_server.empty()) {
         Module::type module = Module::CONTROL_NODE;
         NodeType::type node_type = 
             g_vns_constants.Module2NodeType.find(module)->second; 
@@ -524,21 +543,16 @@ int main(int argc, char *argv[]) {
             g_vns_constants.NodeTypeNames.find(node_type)->second,
             g_vns_constants.INSTANCE_ID_DEFAULT, 
             &evm,
-            var_map["http-server-port"].as<int>(), &sandesh_context);
+            http_server_port,
+            &sandesh_context);
     }
 
-    if (var_map.count("collector-port") && var_map.count("collector")) {
-        int collector_port = var_map["collector-port"].as<int>();
-        std::string collector_server = var_map["collector"].as<string>();
+    if (!collector_server.empty()) {
         Sandesh::ConnectToCollector(collector_server, collector_port);
     }
-    Sandesh::SetLoggingParams(enable_local_logging,
-                              var_map["log-category"].as<string>(),
-                              var_map["log-level"].as<string>());
+    Sandesh::SetLoggingParams(enable_local_logging, log_category, log_level);
 
-    //
     // XXX Disable logging -- for test purposes only
-    //
     if (disable_logging) {
         SetLoggingDisabled(true);
     }
@@ -554,16 +568,13 @@ int main(int argc, char *argv[]) {
     sandesh_context.ifmap_server = &ifmap_server;
     IFMap_Initialize(&ifmap_server);
 
-    bgp_server->config_manager()->Initialize(&config_db, &config_graph,
-                                        var_map["hostname"].as<string>());
-    ControlNode::SetHostname(var_map["hostname"].as<string>());
+    bgp_server->config_manager()->Initialize(&config_db, &config_graph, hostname);
+    ControlNode::SetHostname(hostname);
     BgpConfigParser parser(&config_db);
-    parser.Parse(FileRead(var_map["config-file"].as<string>().c_str()));
+    parser.Parse(FileRead(bgp_config_file.c_str()));
 
     // TODO:  Initialize throws an exception (via boost) in case the
     // user does not have permissions to bind to the port.
-
-    int bgp_port = var_map["bgp-port"].as<int>();
 
     LOG(DEBUG, "Starting Bgp Server at port " << bgp_port);
     bgp_server->session_manager()->Initialize(bgp_port);
@@ -571,10 +582,10 @@ int main(int argc, char *argv[]) {
     XmppServer *xmpp_server = new XmppServer(&evm, hostname);
     XmppInit init;
     XmppChannelConfig xmpp_cfg(false);
-    xmpp_cfg.endpoint.port(var_map["xmpp-port"].as<int>());
+    xmpp_cfg.endpoint.port(xmpp_port);
     xmpp_cfg.FromAddr = XmppInit::kControlNodeJID;
     init.AddXmppChannelConfig(&xmpp_cfg);
-    init.InitServer(xmpp_server, var_map["xmpp-port"].as<int>(), true);
+    init.InitServer(xmpp_server, xmpp_port, true);
 
     // Register XMPP channel peers 
     boost::scoped_ptr<BgpXmppChannelManager> bgp_peer_manager(
@@ -585,12 +596,10 @@ int main(int argc, char *argv[]) {
 
     //Register services with Discovery Service Server
     DiscoveryServiceClient *ds_client = NULL; 
-    if (var_map.count("discovery-server")) { 
+    if (!discovery_server.empty()) {
         tcp::endpoint dss_ep;
-        dss_ep.address(
-            address::from_string(var_map["discovery-server"].as<string>(), 
-            error));
-        dss_ep.port(var_map["discovery-port"].as<int>()); 
+        dss_ep.address(address::from_string(discovery_server, error));
+        dss_ep.port(discovery_port);
         string subscriber_name = 
             g_vns_constants.ModuleNames.find(Module::CONTROL_NODE)->second;
         ds_client = new DiscoveryServiceClient(&evm, dss_ep, subscriber_name); 
@@ -598,36 +607,19 @@ int main(int argc, char *argv[]) {
         ControlNode::SetDiscoveryServiceClient(ds_client); 
   
         // publish xmpp-server service
-        std::string self_ip;
-        if (var_map.count("host-ip")) {
-            self_ip = var_map["host-ip"].as<string>(); 
-        } else {
-            tcp::resolver resolver(*evm.io_service());
-            tcp::resolver::query query(boost::asio::ip::host_name(), "");
-            tcp::resolver::iterator iter = resolver.resolve(query);
-            self_ip = iter->endpoint().address().to_string();
-        }
-
-        // verify string is a valid ip before publishing
-        boost::asio::ip::address::from_string(self_ip, error);
-        if (error) {
-            self_ip.clear();
-        } else { 
-            ControlNode::SetSelfIp(self_ip);
-        }
-
-        if (!self_ip.empty()) {
+        ControlNode::SetSelfIp(host_ip);
+        if (!host_ip.empty()) {
             stringstream pub_ss;
-            pub_ss << "<xmpp-server><ip-address>" << self_ip <<
-                      "</ip-address><port>" << var_map["xmpp-port"].as<int>() <<
+            pub_ss << "<xmpp-server><ip-address>" << host_ip <<
+                      "</ip-address><port>" << xmpp_port <<
                       "</port></xmpp-server>";
-            std::string pub_msg;
+            string pub_msg;
             pub_msg = pub_ss.str();
             ds_client->Publish(DiscoveryServiceClient::XmppService, pub_msg);
         }
 
-        //subscribe to collector service if not configured
-        if (!var_map.count("collector")) {
+        // subscribe to collector service if not configured
+        if (collector_server.empty()) {
             Module::type module = Module::CONTROL_NODE;
             NodeType::type node_type = 
                 g_vns_constants.Module2NodeType.find(module)->second;
@@ -645,24 +637,17 @@ int main(int argc, char *argv[]) {
                                    node_type_name,
                                    g_vns_constants.INSTANCE_ID_DEFAULT, 
                                    &evm,
-                                   var_map["http-server-port"].as<int>(),
+                                   http_server_port,
                                    csf,
                                    list,
                                    &sandesh_context);
         }
     }
 
-    std::string certstore = var_map.count("use-certs") ? 
-                            var_map["use-certs"].as<string>() : string("");
-    std::string map_server_url;
-    if (var_map.count("map-server-url")) {
-        map_server_url = var_map["map-server-url"].as<string>();
-    }
     IFMapServerParser *ifmap_parser = IFMapServerParser::GetInstance("vnc_cfg");
 
-    IFMapManager *ifmapmgr = new IFMapManager(&ifmap_server, map_server_url,
-                var_map["map-user"].as<string>(),
-                var_map["map-password"].as<string>(), certstore,
+    IFMapManager *ifmapmgr = new IFMapManager(&ifmap_server,
+                ifmap_server_url, ifmap_user, ifmap_password, certs_store,
                 boost::bind(&IFMapServerParser::Receive, ifmap_parser,
                             &config_db, _1, _2, _3), evm.io_service(),
                 ds_client);
@@ -683,4 +668,18 @@ int main(int argc, char *argv[]) {
 
     init.Reset();
     return 0;
+}
+
+int main(int argc, char *argv[]) {
+    try {
+        return control_node_main(argc, argv);
+    } catch (boost::program_options::error &e) {
+        LOG(ERROR, "Error " << e.what());
+        cout << "Error " << e.what() << endl;
+    } catch (...) {
+        LOG(ERROR, "Options Parser: Caught fatal unknown exception");
+        cout << "Options Parser: Caught fatal unknown exception" << endl;
+    }
+
+    return(-1);
 }

--- a/src/dns/main.cc
+++ b/src/dns/main.cc
@@ -3,6 +3,7 @@
  */
 
 #include <fstream>
+#include <iostream>
 
 #include <pthread.h>
 #include <boost/program_options.hpp>
@@ -34,6 +35,7 @@
 
 namespace opt = boost::program_options;
 using namespace boost::asio::ip;
+using boost::system::error_code;
 using namespace std;
 
 uint64_t start_time;
@@ -77,48 +79,115 @@ void Dns::ShutdownDiscoveryClient(DiscoveryServiceClient *ds_client) {
     }
 }
 
-int main(int argc, char *argv[]) {
-    bool enable_local_logging = false;
-    const string default_log_file = "<stdout>";
-    opt::options_description desc("Command line options");
-    desc.add_options()
-            ("help", "help message")
-            ("config-file", 
-                opt::value<string>()->default_value("dns_config.xml"),
-                "Configuration file") 
-            ("discovery-server", opt::value<string>(),
-             "IP address of Discovery Server")
-            ("discovery-port",
-             opt::value<int>()->default_value(ContrailPorts::DiscoveryServerPort),
-             "Port of Discovery Server")
-            ("map-server-url", opt::value<string>(), "MAP server URL")
-            ("map-user", opt::value<string>(), "MAP server username")
-            ("map-password", opt::value<string>(), "MAP server password")
-            ("log-local", opt::bool_switch(&enable_local_logging),
-                "Enable local logging of sandesh messages")
-            ("log-level", opt::value<string>()->default_value("SYS_NOTICE"),
-                "Severity level for local logging of sandesh messages")
-            ("log-category", opt::value<string>()->default_value(""),
-                "Category filter for local logging of sandesh messages")
-            ("collector", opt::value<string>(), "IP address of sandesh collector")
-            ("collector-port", opt::value<int>(), "Port of sandesh collector")
-            ("http-server-port",
-                opt::value<int>()->default_value(
-                ContrailPorts::HttpPortDns), "Sandesh HTTP listener port")
-            ("host-ip", opt::value<string>(),
-             "IP address of DNServer")
-            ("use-certs", opt::value<string>(),
-                "Use certificates to communicate with MAP server; Specify certificate store")
-            ("log-file", opt::value<string>()->default_value(default_log_file),
-                "Filename for the logs to be written to")
-            ("version", "Display version information")
-            ;
+static int dns_main(int argc, char *argv[]) {
+    // Create DB table and event manager
+    Dns::Init();
+
+    error_code error;
+
+    // Specify defaults for all options possible.
+    string collector_server;
+    unsigned short collector_port = ContrailPorts::CollectorPort;
+    string dns_config_file = "dns_config.xml";
+    string discovery_server;
+    uint16_t discovery_port = ContrailPorts::DiscoveryServerPort;
+    string hostname(boost::asio::ip::host_name(error));
+    string hostip = GetHostIp(Dns::GetEventManager()->io_service(), hostname);
+    uint16_t http_server_port = ContrailPorts::HttpPortDns;
+    string log_category = "";
+    bool disable_logging = false;
+    string log_file = "<stdout>";
+    string log_level = "SYS_NOTICE";
+    bool log_local = false;
+
+    string ifmap_server_url;
+    string ifmap_password = "control-user-passwd";
+    string ifmap_user = "control-user";
+    string certs_store = "";
+    string config_file = "/etc/contrail/dns.conf";
+
+    // Command line only options.
+    opt::options_description generic("Generic options");
+    generic.add_options()
+        ("conf-file", opt::value<string>()->default_value(config_file),
+             "Configuration file")
+        ("version", "Display version information")
+        ("help", "help message")
+    ;
+
+    // Command line and config file options.
+    opt::options_description config("Configuration options");
+    config.add_options()
+        ("COLLECTOR.port",
+             opt::value<uint16_t>()->default_value(collector_port),
+             "Port of sandesh collector")
+        ("COLLECTOR.server",
+             opt::value<string>()->default_value(collector_server),
+             "IP address of sandesh collector")
+
+        ("DEFAULTS.dns-config-file",
+             opt::value<string>()->default_value(dns_config_file),
+             "DNS Configuration file")
+        ("DEFAULTS.hostip", opt::value<string>()->default_value(hostip),
+             "IP address of control-node")
+        ("DEFAULTS.http-server-port",
+             opt::value<uint16_t>()->default_value(http_server_port),
+             "Sandesh HTTP listener port")
+
+        ("DISCOVERY.port", opt::value<uint16_t>()->default_value(discovery_port),
+            "Port of Discovery Server")
+        ("DISCOVERY.server",
+             opt::value<string>()->default_value(discovery_server),
+              "IP address of Discovery Server")
+
+        ("IFMAP.password", opt::value<string>()->default_value(ifmap_password),
+             "IFMAP server password")
+        ("IFMAP.server-url",
+             opt::value<string>()->default_value(ifmap_server_url),
+             "IFMAP server URL")
+        ("IFMAP.user", opt::value<string>()->default_value(ifmap_user),
+             "IFMAP server username")
+        ("IFMAP.certs-store", opt::value<string>()->default_value(certs_store),
+             "Certificates store to use for communication with IFMAP server")
+
+        ("LOG.category", opt::value<string>()->default_value(log_category),
+            "Category filter for local logging of sandesh messages")
+        ("LOG.disable", opt::bool_switch(&disable_logging),
+             "Disable sandesh logging")
+        ("LOG.file", opt::value<string>()->default_value(log_file),
+             "Filename for the logs to be written to")
+        ("LOG.level", opt::value<string>()->default_value(log_level),
+            "Severity level for local logging of sandesh messages")
+        ("LOG.local", opt::bool_switch(&log_local),
+             "Enable local logging of sandesh messages")
+        ;
+
+    opt::options_description config_file_options;
+    config_file_options.add(config);
+
+    opt::options_description cmdline_options("Allowed options");
+    cmdline_options.add(generic).add(config);
+
+    vector<string> tokens;
+    string line;
     opt::variables_map var_map;
-    opt::store(opt::parse_command_line(argc, argv, desc), var_map);
+
+    // Process options off command line first.
+    opt::store(opt::parse_command_line(argc, argv, cmdline_options), var_map);
+
+    GetOptValue<string>(var_map, config_file, "conf-file", "");
+    ifstream config_file_in;
+    config_file_in.open(config_file.c_str());
+    if (config_file_in.good()) {
+        opt::store(opt::parse_config_file(config_file_in, config_file_options),
+                   var_map);
+    }
+    config_file_in.close();
+
     opt::notify(var_map);
 
     if (var_map.count("help")) {
-        cout << desc << endl;
+        cout << cmdline_options << endl;
         exit(0);
     }
 
@@ -129,34 +198,37 @@ int main(int argc, char *argv[]) {
         exit(0);
     }
 
-    if (var_map["log-file"].as<string>() == default_log_file) {
+    GetOptValue<uint16_t>(var_map, collector_port, "COLLECTOR.port", 0);
+    GetOptValue<string>(var_map, collector_server, "COLLECTOR.server", "");
+    GetOptValue<string>(var_map, dns_config_file, "DEFAULTS.dns-config-file", "");
+    GetOptValue<string>(var_map, hostip, "DEFAULTS.hostip", "");
+    GetOptValue<uint16_t>(var_map, http_server_port, "DEFAULTS.http-server-port", 0);
+    GetOptValue<uint16_t>(var_map, discovery_port, "DISCOVERY.port", 0);
+    GetOptValue<string>(var_map, discovery_server, "DISCOVERY.server", "");
+    GetOptValue<string>(var_map, log_category, "LOG.category", "");
+    GetOptValue<string>(var_map, log_file, "LOG.file", "");
+    GetOptValue<string>(var_map, log_level, "LOG.level", "");
+    GetOptValue<string>(var_map, ifmap_password, "IFMAP.password", "");
+    GetOptValue<string>(var_map, ifmap_server_url, "IFMAP.server-url", "");
+    GetOptValue<string>(var_map, ifmap_user, "IFMAP.user", "");
+    GetOptValue<string>(var_map, certs_store, "IFMAP.certs-store", ""); 
+    if (log_file == "<stdout>") {
         LoggingInit();
     } else {
-        LoggingInit(var_map["log-file"].as<string>());
+        LoggingInit(log_file);
     }
     string build_info_str;
     Dns::GetVersion(build_info_str);
     MiscUtils::LogVersionInfo(build_info_str, Category::DNSAGENT);
-    // Create DB table and event manager
-    Dns::Init();
 
-    int collector_server_port = 0;
-    if (var_map.count("collector-port")) {
-        collector_server_port = var_map["collector-port"].as<int>();
-    }
-    std::string collector_server;
-    if (var_map.count("collector")) {
-        collector_server = var_map["collector"].as<string>();
+    if (!collector_server.empty()) {
         Dns::SetCollector(collector_server);
     }
-    int sandesh_http_port = var_map["http-server-port"].as<int>();
-    Dns::SetHttpPort(sandesh_http_port);
+    Dns::SetHttpPort(http_server_port);
 
     BgpSandeshContext sandesh_context;
-    boost::system::error_code ec;
-    string hostname = host_name(ec);
     Dns::SetHostName(hostname);
-    if (!var_map.count("discovery-server")) {
+    if (discovery_server.empty()) {
         Module::type module = Module::DNS;
         NodeType::type node_type = 
             g_vns_constants.Module2NodeType.find(module)->second;
@@ -166,14 +238,12 @@ int main(int argc, char *argv[]) {
                     g_vns_constants.NodeTypeNames.find(node_type)->second,
                     g_vns_constants.INSTANCE_ID_DEFAULT,
                     Dns::GetEventManager(),
-                    sandesh_http_port, &sandesh_context);
+                    http_server_port, &sandesh_context);
     }
-    if ((collector_server_port != 0) && (!collector_server.empty())) {
-        Sandesh::ConnectToCollector(collector_server, collector_server_port);
+    if ((collector_port != 0) && (!collector_server.empty())) {
+        Sandesh::ConnectToCollector(collector_server, collector_port);
     }
-    Sandesh::SetLoggingParams(enable_local_logging,
-                              var_map["log-category"].as<string>(),
-                              var_map["log-level"].as<string>());
+    Sandesh::SetLoggingParams(log_local, log_category, log_level);
 
     DB config_db;
     DBGraph config_graph;
@@ -186,7 +256,7 @@ int main(int argc, char *argv[]) {
     Dns::SetDnsManager(&dns_manager);
     dns_manager.Initialize(&config_db, &config_graph);
     DnsConfigParser parser(&config_db);
-    parser.Parse(FileRead(var_map["config-file"].as<string>()));
+    parser.Parse(FileRead(dns_config_file));
 
     Dns::SetProgramName(argv[0]);
     DnsAgentXmppManager::Init();
@@ -202,31 +272,22 @@ int main(int argc, char *argv[]) {
 
     //Register services with Discovery Service Server
     DiscoveryServiceClient *ds_client = NULL;
-    if (var_map.count("discovery-server")) {
+    if (!discovery_server.empty()) {
+        error_code ec;
         tcp::endpoint dss_ep;
-        dss_ep.address(
-            address::from_string(var_map["discovery-server"].as<string>(), ec));
-        dss_ep.port(var_map["discovery-port"].as<int>());
+        dss_ep.address(address::from_string(discovery_server, ec));
+        dss_ep.port(discovery_port);
         ds_client = new DiscoveryServiceClient(Dns::GetEventManager(), dss_ep,
             g_vns_constants.ModuleNames.find(Module::DNS)->second);
         ds_client->Init();
         Dns::SetDiscoveryServiceClient(ds_client);
 
         // Publish DNServer Service
-        string self_ip; 
-        if (var_map.count("host-ip")) {
-            self_ip = var_map["host-ip"].as<string>();
-        } else {
-            tcp::resolver resolver(*(Dns::GetEventManager()->io_service()));
-            tcp::resolver::query query(host_name(ec), "");
-            tcp::resolver::iterator iter = resolver.resolve(query);
-            self_ip = iter->endpoint().address().to_string();
-        }
-        Dns::SetSelfIp(self_ip);
+        Dns::SetSelfIp(hostip);
 
-        if (!self_ip.empty()) {
+        if (!hostip.empty()) {
             stringstream pub_ss;
-            pub_ss << "<dns-server><ip-address>" << self_ip <<
+            pub_ss << "<dns-server><ip-address>" << hostip <<
                       "</ip-address><port>" << ContrailPorts::DnsXmpp <<
                       "</port></dns-server>";
             std::string pub_msg;
@@ -235,7 +296,7 @@ int main(int argc, char *argv[]) {
         }
 
         //subscribe to collector service if not configured
-        if (!var_map.count("collector")) {
+        if (collector_server.empty()) {
             Module::type module = Module::DNS;
             NodeType::type node_type = 
                 g_vns_constants.Module2NodeType.find(module)->second;
@@ -252,27 +313,20 @@ int main(int argc, char *argv[]) {
                                    hostname, node_type_name,
                                    g_vns_constants.INSTANCE_ID_DEFAULT,
                                    Dns::GetEventManager(),
-                                   sandesh_http_port,
+                                   http_server_port,
                                    csf,
                                    list,
                                    &sandesh_context);
         }
     }
 
-    std::string certstore = var_map.count("use-certs") ? 
-                            var_map["use-certs"].as<string>() : string("");
-    std::string map_server_url;
-    if (var_map.count("map-server-url")) {
-        map_server_url = var_map["map-server-url"].as<string>();
-    }
     IFMapServerParser *ifmap_parser = IFMapServerParser::GetInstance("vnc_cfg");
 
-    IFMapManager *ifmapmgr = new IFMapManager(&ifmap_server, map_server_url,
-                        var_map["map-user"].as<string>(),
-                        var_map["map-password"].as<string>(), certstore,
-                        boost::bind(&IFMapServerParser::Receive, ifmap_parser,
-                                &config_db, _1, _2, _3),
-                        Dns::GetEventManager()->io_service(), ds_client);
+    IFMapManager *ifmapmgr = new IFMapManager(&ifmap_server, ifmap_server_url,
+                                            ifmap_user, ifmap_password, certs_store,
+                                    boost::bind(&IFMapServerParser::Receive, ifmap_parser,
+                                                &config_db, _1, _2, _3),
+                                    Dns::GetEventManager()->io_service(), ds_client);
     ifmap_server.set_ifmap_manager(ifmapmgr);
 
     Dns::GetEventManager()->Run();
@@ -280,4 +334,18 @@ int main(int argc, char *argv[]) {
     Dns::ShutdownDiscoveryClient(ds_client);
 
     return 0;
+}
+
+int main(int argc, char *argv[]) {
+    try {
+        return dns_main(argc, argv);
+    } catch (boost::program_options::error &e) {
+        LOG(ERROR, "Error " << e.what());
+        cout << "Error " << e.what() << endl;
+    } catch (...) {
+        LOG(ERROR, "Options Parser: Caught fatal unknown exception");
+        cout << "Options Parser: Caught fatal unknown exception" << endl;
+    }
+
+    return(-1);
 }

--- a/src/opserver/test/utils/analytics_fixture.py
+++ b/src/opserver/test/utils/analytics_fixture.py
@@ -68,15 +68,16 @@ class Collector(object):
         assert(self._instance == None)
         self._log_file = '/tmp/vizd.messages.' + str(self.listen_port)
         args = [self.analytics_fixture.builddir + '/analytics/vizd',
-            '--cassandra-server-list', '127.0.0.1:' +
+            '--DEFAULTS.cassandra-server', '127.0.0.1:' +
             str(self.analytics_fixture.cassandra_port),
-            '--redis-uve-port', 
+            '--REDIS.port', 
             str(self._redis_uve.port),
-            '--listen-port', str(self.listen_port),
-            '--http-server-port', str(self.http_port),
-            '--log-file', self._log_file]
+            '--DEFAULTS.listen-port', str(self.listen_port),
+            '--DEFAULTS.http-server-port', str(self.http_port),
+            '--LOG.file', self._log_file]
         if self._is_dup is True:
-            args.append('--dup')
+            args.append('--DEFAULTS.dup')
+        print args
         self._instance = subprocess.Popen(args, stdout=subprocess.PIPE,
                                           stderr=subprocess.PIPE)
         self._logger.info('Setting up Vizd: %s' % (' '.join(args))) 
@@ -200,17 +201,17 @@ class QueryEngine(object):
         assert(self._instance == None)
         self._log_file = '/tmp/qed.messages.' + str(self.listen_port)
         args = [self.analytics_fixture.builddir + '/query_engine/qedt',
-                '--redis-port', str(self.analytics_fixture.redis_query.port),
-                '--cassandra-server-list', '127.0.0.1:' +
+                '--REDIS.port', str(self.analytics_fixture.redis_query.port),
+                '--DEFAULTS.cassandra-server', '127.0.0.1:' +
                 str(self.analytics_fixture.cassandra_port),
-                '--http-server-port', str(self.listen_port),
-                '--log-local', '--log-level', 'SYS_DEBUG',
-                '--log-file', self._log_file,
-                '--collectors', self.primary_collector]
+                '--DEFAULTS.http-server-port', str(self.listen_port),
+                '--LOG.local', '--LOG.level', 'SYS_DEBUG',
+                '--LOG.file', self._log_file,
+                '--DEFAULTS.collector-server', self.primary_collector]
         if self.secondary_collector is not None:
             args.append(self.secondary_collector)
         if analytics_start_time is not None:
-            args += ['--start-time', str(analytics_start_time)]
+            args += ['--DEFAULTS.start-time', str(analytics_start_time)]
         self._instance = subprocess.Popen(args,
                                           stdout=subprocess.PIPE,
                                           stderr=subprocess.PIPE)

--- a/src/vnsw/agent/init/agent_init.cc
+++ b/src/vnsw/agent/init/agent_init.cc
@@ -301,31 +301,21 @@ void AgentInit::TriggerInit() {
     trigger_list_.push_back(t);
 }
 
-void AgentInit::Init(AgentParam *param, Agent *agent,
-                     const boost::program_options::variables_map &var_map) {
+void AgentInit::Init(AgentParam *param, Agent *agent, bool disable_vhost,
+                     bool disable_ksync, bool disable_services,
+                     bool disable_packet_services) {
 
-    if (var_map.count("disable-vhost")) {
-        create_vhost_ = false;
-    }
-
-    if (var_map.count("disable-ksync")) {
-        ksync_enable_ = false;
-    }
-
-    if (var_map.count("disable-services")) {
-        services_enable_ = false;
-    }
-
-    if (var_map.count("disable-packet")) {
-        packet_enable_ = false;
-    }
+    create_vhost_ = !disable_vhost;
+    ksync_enable_ = !disable_ksync;
+    services_enable_ = !disable_services;
+    packet_enable_ = !disable_packet_services;
     params_ = param;
     agent_ = agent;
 }
 
 // TODO: Move the following code to state based initialization
 void AgentInit::Start() {
-    if (params_->log_file() == "") {
+    if (params_->log_file() == "" || params_->log_file() == "<stdout>") {
         LoggingInit();
     } else {
         LoggingInit(params_->log_file());

--- a/src/vnsw/agent/init/agent_init.h
+++ b/src/vnsw/agent/init/agent_init.h
@@ -69,8 +69,9 @@ public:
     void CreateDefaultVrf();
     void CreateDefaultNextHops();
     void CreateInterfaces(DB *db);
-    void Init(AgentParam *param, Agent *agent,
-              const boost::program_options::variables_map &var_map);
+    void Init(AgentParam *param, Agent *agent, bool disable_vhost = false,
+              bool disable_ksync = false, bool disable_services = false,
+              bool disable_packet_services = false);
     void Start();
     void InitXenLinkLocalIntf();
     void InitVmwareInterface();

--- a/src/vnsw/agent/init/agent_param.cc
+++ b/src/vnsw/agent/init/agent_param.cc
@@ -24,6 +24,7 @@
 
 #include <base/logging.h>
 #include <base/misc_utils.h>
+#include <base/util.h>
 #include <sandesh/sandesh_types.h>
 #include <sandesh/sandesh.h>
 #include <sandesh/sandesh_trace.h>
@@ -371,60 +372,43 @@ void AgentParam::InitFromConfig() {
 }
 
 void AgentParam::InitFromArguments
-    (const boost::program_options::variables_map &var_map) {
+    (const boost::program_options::variables_map &var_map, bool log_local) {
+    string collector_server;
+    string xen_ll_ip_address;
+    string mode = "kvm";
 
-    if (var_map.count("log-local")) {
-        log_local_ = true;
-    }
+    log_local_ = log_local;
+    GetOptValue<string>(var_map, log_category_, "LOG.category", "");
+    GetOptValue<string>(var_map, log_file_, "LOG.file", "");
+    GetOptValue<string>(var_map, log_level_, "LOG.level", "");
+    GetOptValue<uint16_t>(var_map, collector_port_, "COLLECTOR.port", 0);
+    GetOptValue<string>(var_map, collector_server, "COLLECTOR.server", "");
+    GetOptValue<uint16_t>(var_map, http_server_port_, "DEFAULTS.http-server-port", 0);
+    GetOptValue<string>(var_map, host_name_, "DEFAULTS.hostname", "");
+    GetOptValue<string>(var_map, mode, "HYPERVISOR.type", "");
+    GetOptValue<string>(var_map, xen_ll_.name_, "HYPERVISOR.xen-ll-port", "");
+    GetOptValue<string>(var_map, xen_ll_ip_address, "HYPERVISOR.xen-ll-ip-address", "");
+    GetOptValue<int>(var_map, xen_ll_.plen_, "HYPERVISOR.xen-ll-prefix-len", 0);
+    GetOptValue<string>(var_map, vmware_physical_port_, "HYPERVISOR.vmware-physical-port", "");
 
-    if (var_map.count("log-level")) {
-        log_level_ = var_map["log-level"].as<string>();
-    }
-
-    if (var_map.count("log-category")) {
-        log_category_ = var_map["log-category"].as<string>();
-    }
-
-    if (var_map.count("collector")) {
+    if (!collector_server.empty()) {
         Ip4Address addr;
         if (GetIpAddress(var_map["collector"].as<string>(), &addr)) {
             collector_ = addr;
         }
     }
 
-    if (var_map.count("collector-port")) {
-        collector_port_ = var_map["collector-port"].as<int>();
+    if (mode == "xen") {
+        mode_ = AgentParam::MODE_XEN;
+    } else if (mode == "vmware") {
+        mode_ = AgentParam::MODE_VMWARE;
+    } else {
+        mode_ = AgentParam::MODE_KVM;
     }
 
-    if (var_map.count("http-server-port")) {
-        http_server_port_ = var_map["http-server-port"].as<int>();
-    }
-
-    if (var_map.count("host-name")) {
-        host_name_ = var_map["host-name"].as<string>().c_str();
-    }
-
-    if (var_map.count("log-file")) {
-        log_file_ = var_map["log-file"].as<string>();
-    }
-
-    if (var_map.count("hypervisor")) {
-        if (var_map["hypervisor"].as<string>() == "xen") {
-            mode_ = AgentParam::MODE_XEN;
-        } else if (var_map["hypervisor"].as<string>() == "vmware") {
-            mode_ = AgentParam::MODE_VMWARE;
-        } else {
-            mode_ = AgentParam::MODE_KVM;
-        }
-    }
-
-    if (var_map.count("xen-ll-port")) {
-        xen_ll_.name_ = var_map["xen-ll-port"].as<string>();
-    }
-
-    if (var_map.count("xen-ll-ip-address")) {
+    if (!xen_ll_ip_address.empty()) {
         Ip4Address addr;
-        if (!GetIpAddress(var_map["xen-ll-ip-address"].as<string>(), &addr)) {
+        if (!GetIpAddress(xen_ll_ip_address, &addr)) {
             LOG(ERROR, "Error parsing xen-ll-ip-address");
             exit(EINVAL);
         }
@@ -432,15 +416,10 @@ void AgentParam::InitFromArguments
     }
 
     if (var_map.count("xen-ll-prefix-len")) {
-        xen_ll_.plen_ = var_map["xen-ll-prefix-len"].as<int>();
         if (xen_ll_.plen_ <= 0 || xen_ll_.plen_ >= 32) {
             LOG(ERROR, "Error parsing argument for xen-ll-prefix-len");
             exit(EINVAL);
         }
-    }
-
-    if (var_map.count("vmware-physical-port")) {
-        vmware_physical_port_ = var_map["vmware-physical-port"].as<string>();
     }
 
     return;
@@ -514,13 +493,14 @@ void AgentParam::Validate() {
 }
 
 void AgentParam::Init(const string &config_file, const string &program_name,
-                      const boost::program_options::variables_map &var_map) {
+                      const boost::program_options::variables_map &var_map,
+                      bool log_local) {
     config_file_ = config_file;
     program_name_ = program_name;
 
     InitFromSystem();
     InitFromConfig();
-    InitFromArguments(var_map);
+    InitFromArguments(var_map, log_local);
     Validate();
     vgw_config_table_->Init(config_file.c_str());
     LogConfig();

--- a/src/vnsw/agent/init/agent_param.h
+++ b/src/vnsw/agent/init/agent_param.h
@@ -96,15 +96,16 @@ public:
 
     void Init(const std::string &config_file,
               const std::string &program_name,
-              const boost::program_options::variables_map &var_map);
+              const boost::program_options::variables_map &var_map,
+              bool log_local = false);
 
 private:
     void ValidateLinkLocalFlows();
     void Validate();
     void InitFromSystem();
     void InitFromConfig();
-    void InitFromArguments
-        (const boost::program_options::variables_map &var_map);
+    void InitFromArguments(const boost::program_options::variables_map &var_map,
+                           bool log_local = false);
     void LogConfig() const;
 
     PortInfo vhost_;

--- a/src/vnsw/agent/main.cc
+++ b/src/vnsw/agent/main.cc
@@ -2,8 +2,12 @@
  * Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
  */
 
-#include <boost/uuid/string_generator.hpp>
+#include <fstream>
+#include <iostream>
+
+#include <boost/asio/ip/host_name.hpp>
 #include <boost/program_options.hpp>
+#include <boost/uuid/string_generator.hpp>
 #include <base/logging.h>
 #include <base/contrail_ports.h>
 
@@ -55,64 +59,117 @@ bool GetBuildInfo(std::string &build_info_str) {
     return MiscUtils::GetBuildInfo(MiscUtils::Agent, BuildInfo, build_info_str);
 }
 
-int main(int argc, char *argv[]) {
-    opt::options_description desc("Command line options");
-    desc.add_options()
+static int agent_main(int argc, char *argv[]) {
+    boost::system::error_code error;
+
+    string init_file = "/etc/contrail/agent.conf";
+    string conf_file = "/etc/contrail/vrouter.conf";
+    string hostname(boost::asio::ip::host_name(error));
+    bool log_local = false;
+    bool disable_vhost = false;
+    bool disable_ksync = false;
+    bool disable_services = false;
+    bool disable_packet_services = false;
+
+    // Command line only options.
+    opt::options_description generic("Generic options");
+    generic.add_options()
+        ("conf-file", opt::value<string>()->default_value(conf_file),
+             "Configuration file")
         ("help", "help message")
-        ("config-file", opt::value<string>(), "Configuration file")
-        ("disable-vhost", "Create vhost interface")
-        ("disable-ksync", "Disable kernel synchronization")
-        ("disable-services", "Disable services")
-        ("disable-packet", "Disable packet services")
-        ("log-local", "Enable local logging of sandesh messages")
-        ("log-level", opt::value<string>()->default_value("SYS_DEBUG"),
-         "Severity level for local logging of sandesh messages")
-        ("log-category", opt::value<string>()->default_value(""),
-         "Category filter for local logging of sandesh messages")
-        ("collector", opt::value<string>(), "IP address of sandesh collector")
-        ("collector-port", opt::value<int>(), "Port of sandesh collector")
-        ("http-server-port",
-         opt::value<int>()->default_value(ContrailPorts::HttpPortAgent),
-         "Sandesh HTTP listener port")
-        ("host-name", opt::value<string>(), "Specific Host Name")
-        ("log-file", opt::value<string>(),
-         "Filename for the logs to be written to")
-        ("hypervisor", opt::value<string>(), "Type of hypervisor <kvm|xen>")
-        ("xen-ll-port", opt::value<string>(), 
-         "Port name on host for link-local network")
-        ("xen-ll-ip-address", opt::value<string>(),
-         "IP Address for the link local port")
-        ("xen-ll-prefix-len", opt::value<int>(),
-         "Prefix for link local IP Address")
-        ("vmware-physical-port", opt::value<string>(),
-         "Physical port used to connect to VMs in VMWare environement")
         ("version", "Display version information")
-        ;
+    ;
+
+    // Command line and config file options.
+    opt::options_description config("Configuration options");
+    config.add_options()
+       ("COLLECTOR.port", opt::value<uint16_t>()->default_value(ContrailPorts::CollectorPort),
+            "Port of sandesh collector")
+       ("COLLECTOR.server", opt::value<string>()->default_value(""),
+            "IP address of sandesh collector")
+
+       ("DEFAULTS.config-file", opt::value<string>()->default_value(init_file),
+            "Agent Configuration file")
+       ("DEFAULTS.hostname", opt::value<string>()->default_value(hostname),
+            "Specific Host Name")
+       ("DEFAULTS.http-server-port",
+            opt::value<uint16_t>()->default_value(ContrailPorts::HttpPortAgent),
+            "Sandesh HTTP listener port")
+
+       ("HYPERVISOR.type", opt::value<string>()->default_value("kvm"),
+            "Type of hypervisor <kvm|xen>")
+       ("HYPERVISOR.xen-ll-port",
+           opt::value<string>()->default_value(""), 
+           "Port name on host for link-local network")
+       ("HYPERVISOR.xen-ll-ip-address",
+            opt::value<string>()->default_value(""),
+            "IP Address for the link local port")
+       ("HYPERVISOR.xen-ll-prefix-len",
+            opt::value<int>()->default_value(0),
+            "IP Prefix Length for the link local address")
+       ("HYPERVISOR.vmware-physical-port",
+            opt::value<string>()->default_value(""), 
+            "Physical port used to connect to VMs in VMWare environement")
+
+       ("KERNEL.disable-vhost", opt::bool_switch(&disable_vhost),
+            "Disable vhost interface")
+       ("KERNEL.disable-ksync", opt::bool_switch(&disable_ksync),
+            "Disable kernel synchronization")
+       ("KERNEL.disable-services", opt::bool_switch(&disable_services),
+            "Disable services")
+       ("KERNEL.disable-packet", opt::bool_switch(&disable_packet_services),
+            "Disable packet services")
+
+       ("LOG.category", opt::value<string>()->default_value(""),
+           "Category filter for local logging of sandesh messages")
+       ("LOG.file", opt::value<string>()->default_value("<stdout>"),
+        "Filename for the logs to be written to")
+       ("LOG.level", opt::value<string>()->default_value("SYS_DEBUG"),
+           "Severity level for local logging of sandesh messages")
+       ("LOG.local", opt::bool_switch(&log_local),
+            "Enable local logging of sandesh messages")
+       ;
+
+  
+    opt::options_description config_file_options;
+    config_file_options.add(config);
+  
+    opt::options_description cmdline_options("Allowed options");
+    cmdline_options.add(generic).add(config);
+  
+    vector<string> tokens;
+    string line;
     opt::variables_map var_map;
-    try {
-        opt::store(opt::parse_command_line(argc, argv, desc), var_map);
-        opt::notify(var_map);
-    } catch (...) {
-        cout << "Invalid arguments. ";
-        cout << desc << endl;
-        exit(0);
-    }
+  
+    // Process options off command line first.
+    opt::store(opt::parse_command_line(argc, argv, cmdline_options), var_map);
 
+    // Process options off configuration file.
+    GetOptValue<string>(var_map, conf_file, "conf-file", "");
+    ifstream conf_file_in;
+    conf_file_in.open(conf_file.c_str());
+    if (conf_file_in.good()) {
+        opt::store(opt::parse_config_file(conf_file_in, config_file_options),
+                   var_map);
+    }
+    conf_file_in.close();
+
+    opt::notify(var_map);
+  
     if (var_map.count("help")) {
-        cout << desc << endl;
+        std::cout << cmdline_options << std::endl;
         exit(0);
     }
-
+  
     if (var_map.count("version")) {
         string build_info;
         MiscUtils::GetBuildInfo(MiscUtils::Agent, BuildInfo, build_info);
-        cout <<  build_info << endl;
+        std::cout <<  build_info << std::endl;
         exit(0);
     }
 
-    string init_file = "";
-    if (var_map.count("config-file")) {
-        init_file = var_map["config-file"].as<string>();
+    if (var_map.count("DEFAULTS.config-file")) {
+        GetOptValue<string>(var_map, init_file, "DEFAULTS.config-file", "");
         struct stat s;
         if (stat(init_file.c_str(), &s) != 0) {
             LOG(ERROR, "Error opening config file <" << init_file 
@@ -130,11 +187,12 @@ int main(int argc, char *argv[]) {
 
     // Read agent parameters from config file and arguments
     AgentParam param;
-    param.Init(init_file, argv[0], var_map);
+    param.Init(init_file, argv[0], var_map, log_local);
 
     // Initialize the agent-init control class
     AgentInit init;
-    init.Init(&param, &agent, var_map);
+    init.Init(&param, &agent, disable_vhost, disable_ksync, disable_services,
+              disable_packet_services);
 
     // Initialize agent and kick start initialization
     agent.Init(&param, &init);
@@ -142,4 +200,18 @@ int main(int argc, char *argv[]) {
     Agent::GetInstance()->GetEventManager()->Run();
 
     return 0;
+}
+
+int main(int argc, char *argv[]) {
+    try {
+        return agent_main(argc, argv);
+    } catch (boost::program_options::error &e) {
+        LOG(ERROR, "Error " << e.what());
+        cout << "Error " << e.what() << endl;
+    } catch (...) {
+        LOG(ERROR, "Options Parser: Caught fatal unknown exception");
+        cout << "Options Parser: Caught fatal unknown exception" << endl;
+    }
+
+    return(-1);
 }

--- a/src/vnsw/agent/test/test_init.cc
+++ b/src/vnsw/agent/test/test_init.cc
@@ -56,7 +56,7 @@ TestClient *TestInit(const char *init_file, bool ksync_init, bool pkt_init,
                                Agent::GetInstance()->GetEventManager(),
                                sandesh_port, NULL);
 
-    init->Init(param, agent, var_map);
+    init->Init(param, agent);
     init->set_ksync_enable(ksync_init);
     init->set_packet_enable(true);
     init->set_services_enable(services_init);
@@ -117,7 +117,7 @@ TestClient *StatsTestInit() {
                                Agent::GetInstance()->GetEventManager(),
                                sandesh_port, NULL);
 
-    init->Init(param, agent, var_map);
+    init->Init(param, agent);
     init->set_ksync_enable(true);
     init->set_packet_enable(true);
     init->set_services_enable(true);
@@ -164,7 +164,7 @@ TestClient *VGwInit(const string &init_file, bool ksync_init) {
                                Agent::GetInstance()->GetEventManager(),
                                0, NULL);
 
-    init->Init(param, agent, var_map);
+    init->Init(param, agent);
     init->set_ksync_enable(ksync_init);
     init->set_packet_enable(true);
     init->set_services_enable(true);


### PR DESCRIPTION
o control-node
o collector (vizd)
o dns
o query-engine
o vnswad (vrouter)

These daemons now take configuration in the standard .ini format.
Default configuration file is read off

/etc/contrail/control-node.conf
/etc/contrail/collector.conf
/etc/contrail/dns.conf
/etc/contrail/query-engine.conf
/etc/contrail/vrouter.conf

One can override the values from the config file through command line option
as well. e.g. --LOG.level=DEBUG, --DEFAULTS.hostip=1.2.3.4, etc.

Use --help to see various options available. Package also places the default
config file under /etc/contrail/.

When configuration changes are made, the process must be _restarted_ to
take effect.
