### PR TITLE
Fixing contrail-version to display only installed packages Bug:2478

### DIFF
--- a/src/config/utils/contrail-version-deb
+++ b/src/config/utils/contrail-version-deb
@@ -27,6 +27,7 @@ fi
 echo "Package                                Version                 Build-ID | Repo | Package Name"
 echo "-------------------------------------- ----------------------- ----------------------------------"
 for i in `cat $CONTRAILRPMS`; do
+  dpkg -s $i 2> /dev/null 1> /dev/null
   ret_code=$?
   if [ $ret_code == 0 ]; then
       v="";


### PR DESCRIPTION
Fixing the contrail-version-deb to display only installed packages.
