### PR TITLE
Close fd before attempting connect to zookeeper

### DIFF
--- a/src/config/common/discovery.py
+++ b/src/config/common/discovery.py
@@ -123,7 +123,9 @@ class DiscoveryService(object):
         while True:
             try:
                 if restart:
-                    self._zk_client.restart()
+                    self._zk_client.stop()
+                    self._zk_client.close()
+                    self._zk_client.start()
                 else:
                     self._zk_client.start()
                 break

--- a/src/discovery/disc_zk.py
+++ b/src/discovery/disc_zk.py
@@ -57,7 +57,12 @@ class DiscoveryZkClient(object):
     def connect(self, restart = False):
         while True:
             try:
-                self._zk.restart() if restart else self._zk.start()
+                if restart:
+                    self._zk.stop() 
+                    self._zk.cancel() 
+                    self._zk.start() 
+                else:
+                    self._zk.start()
                 break
             except gevent.event.Timeout as e:
                 self.syslog(


### PR DESCRIPTION
Reached fd limit on discovery server due to number of connects to zookeeper, need to close fd before reconnect.
