### PR TITLE
Enable agant code test run with kernel as well and add sample 

### DIFF
--- a/src/vnsw/agent/test/test_global_vrouter_config.cc
+++ b/src/vnsw/agent/test/test_global_vrouter_config.cc
@@ -28,9 +28,6 @@
 using namespace std;
 using namespace boost::assign;
 
-#define MAX_VNET 2
-int test_fd[MAX_VNET];
-
 void RouterIdDepInit() {
 }
 
@@ -112,16 +109,10 @@ TEST_F(CfgTest, TunnelType_test) {
 int main(int argc, char **argv) {
     GETUSERARGS();
 
-    if (ksync_init) {
-        CreateTapInterfaces("vnet", MAX_VNET, test_fd);
-    }
     client = TestInit(init_file, ksync_init);
     int ret = RUN_ALL_TESTS();
     client->WaitForIdle();
     TestShutdown();
     delete client;
-    if (ksync_init) {
-        DeleteTapIntf(test_fd, MAX_VNET);
-    }
     return ret;
 }

--- a/src/vnsw/agent/test/test_util.cc
+++ b/src/vnsw/agent/test/test_util.cc
@@ -13,6 +13,8 @@ using namespace std;
 
 Peer *bgp_peer_;
 TestClient *client;
+#define MAX_VNET 10
+int test_tap_fd[MAX_VNET];
 
 uuid MakeUuid(int id) {
     char str[50];
@@ -1756,6 +1758,10 @@ void DeleteVmportEnv(struct PortInfo *input, int count, int del_vn, int acl_id,
     if (acl_id) {
         DelNode("access-control-list", acl_name);
     }
+
+    if (Agent::GetInstance()->init()->ksync_enable()) {
+        DeleteTapIntf(test_tap_fd, count);
+    }
 }
 
 void CreateVmportFIpEnv(struct PortInfo *input, int count, int acl_id, 
@@ -1817,6 +1823,10 @@ void CreateVmportEnvInternal(struct PortInfo *input, int count, int acl_id,
     char vrf_name[MAX_TESTNAME_LEN];
     char acl_name[MAX_TESTNAME_LEN];
     char instance_ip[MAX_TESTNAME_LEN];
+
+    if (Agent::GetInstance()->init()->ksync_enable()) {
+        CreateTapInterfaces("vnet", count, test_tap_fd);
+    }
 
     if (acl_id) {
         sprintf(acl_name, "acl%d", acl_id);


### PR DESCRIPTION
1) Use ksync_init in testinit to determine test_mode status. If agent UT needs to be run with kernel then disable test_mode.
2) Add sample code (in test_global_vrouter_config.cc) to enable tap interfaces in kernel. 
