### PR TITLE
Dns config ini format

### DIFF
--- a/src/control-node/options.cc
+++ b/src/control-node/options.cc
@@ -119,7 +119,7 @@ void Options::Initialize(EventManager &evm,
         ("DISCOVERY.server", opt::value<string>(),
              "IP address of Discovery Server")
 
-        ("IFMAP.certs_store",
+        ("IFMAP.certs_store",  opt::value<string>(),
              "Certificates store to use for communication with IFMAP server")
         ("IFMAP.password", opt::value<string>()->default_value(
                                                      "control_user_passwd"),

--- a/src/dns/SConscript
+++ b/src/dns/SConscript
@@ -44,7 +44,7 @@ if sys.platform != 'darwin':
                       '-lifmap_server', '-rdynamic',
                       '-Wl,--no-whole-archive'])
 
-dnsd = env.Program(target = 'dnsd', source = ['main.cc', 'dns_options.cc'])
+dnsd = env.Program(target = 'dnsd', source = ['main.cc'])
 env.Alias('src/dns:dnsd', dnsd)
 env.Default(dnsd)
 

--- a/src/dns/cmn/SConscript
+++ b/src/dns/cmn/SConscript
@@ -23,12 +23,12 @@ buildinfo_dep_libs = ['../../dns/cfg/libdns_cfg.a', '../../dns/mgr/libmgr.a', '.
 if sys.platform != 'darwin':
     buildinfo_dep_libs += [ '../../../lib/libtbb_debug.so.2' ]
 
-cmn_sources = ['dns.cc']
+cmn_sources = ['dns.cc', 'dns_options.cc']
 
 env.GenerateBuildInfoCode(
     target = ['buildinfo.h', 'buildinfo.cc'],
     source = buildinfo_dep_libs +  cmn_sources +
-                 ['../main.cc', '../dns_options.cc'],
+                 ['../main.cc'],
     path = Dir('.').path)
 
 env.Depends('dns.o', 'buildinfo.cc')

--- a/src/dns/cmn/dns_options.cc
+++ b/src/dns/cmn/dns_options.cc
@@ -10,8 +10,8 @@
 #include "base/logging.h"
 #include "base/misc_utils.h"
 #include "base/util.h"
-#include "dns/cmn/buildinfo.h"
-#include "dns/dns_options.h"
+#include "cmn/buildinfo.h"
+#include "cmn/dns_options.h"
 
 using namespace std;
 using namespace boost::asio::ip;
@@ -25,16 +25,8 @@ bool Options::Parse(EventManager &evm, int argc, char *argv[]) {
     opt::options_description cmdline_options("Allowed options");
     Initialize(evm, cmdline_options);
 
-    try {
-        Process(argc, argv, cmdline_options);
-        return true;
-    } catch (boost::program_options::error &e) {
-        cout << "Error " << e.what() << endl;
-    } catch (...) {
-        cout << "Options Parser: Caught fatal unknown exception" << endl;
-    }
-
-    return false;
+    Process(argc, argv, cmdline_options);
+    return true;
 }
 
 // Initialize dns's command line option tags with appropriate default
@@ -109,7 +101,7 @@ void Options::Initialize(EventManager &evm,
         ("DISCOVERY.server", opt::value<string>(),
              "IP address of Discovery Server")
 
-        ("IFMAP.certs_store",
+        ("IFMAP.certs_store",  opt::value<string>(),
              "Certificates store to use for communication with IFMAP server")
         ("IFMAP.password", opt::value<string>()->default_value(
                                                      "dns_user_passwd"),

--- a/src/dns/cmn/dns_options.h
+++ b/src/dns/cmn/dns_options.h
@@ -9,7 +9,7 @@
 class Options {
 public:
     Options();
-    bool Parse(EventManager &evm, int argc, char **argv);
+    bool Parse(EventManager &evm, int argc, char *argv[]);
 
     const std::string dns_config_file() const { return dns_config_file_; }
     const std::string collector_server() const { return collector_server_; }

--- a/src/dns/test/SConscript
+++ b/src/dns/test/SConscript
@@ -48,8 +48,7 @@ env.Alias('src/dns:dns_config_test', dns_config_test)
 dns_bind_test = env.UnitTest('dns_bind_test', ['dns_bind_test.cc'])
 env.Alias('src/dns:dns_bind_test', dns_bind_test)
 
-dns_options_test = env.UnitTest('dns_options_test', ['../dns_options.cc',
-                                                     'dns_options_test.cc'])
+dns_options_test = env.UnitTest('dns_options_test', ['dns_options_test.cc'])
 env.Alias('src/dns:dns_options_test', dns_options_test)
 
 #dns_mgr_test = env.UnitTest('dns_mgr_test', ['dns_mgr_test.cc'])

--- a/src/dns/test/dns_options_test.cc
+++ b/src/dns/test/dns_options_test.cc
@@ -9,7 +9,7 @@
 #include "base/util.h"
 #include "base/logging.h"
 #include "base/test/task_test_util.h"
-#include "dns/dns_options.h"
+#include "cmn/dns_options.h"
 #include "io/event_manager.h"
 
 using namespace std;
@@ -38,7 +38,7 @@ protected:
 TEST_F(OptionsTest, NoArguments) {
     int argc = 1;
     char *argv[argc];
-    char argv_0[] = "options_test";
+    char argv_0[] = "dns_options_test";
     argv[0] = argv_0;
 
     options_.Parse(evm_, argc, argv);
@@ -56,7 +56,7 @@ TEST_F(OptionsTest, NoArguments) {
     EXPECT_EQ(options_.log_disable(), false);
     EXPECT_EQ(options_.log_file(), "<stdout>");
     EXPECT_EQ(options_.log_files_count(), 10);
-    EXPECT_EQ(options_.log_file_size(), 10*1024*1024);
+    EXPECT_EQ(options_.log_file_size(), 1024*1024);
     EXPECT_EQ(options_.log_level(), "SYS_NOTICE");
     EXPECT_EQ(options_.log_local(), false);
     EXPECT_EQ(options_.ifmap_server_url(), "");
@@ -69,7 +69,7 @@ TEST_F(OptionsTest, NoArguments) {
 TEST_F(OptionsTest, DefaultConfFile) {
     int argc = 2;
     char *argv[argc];
-    char argv_0[] = "options_test";
+    char argv_0[] = "dns_options_test";
     char argv_1[] = "--conf_file=controller/src/dns/dns.conf";
     argv[0] = argv_0;
     argv[1] = argv_1;
@@ -90,7 +90,7 @@ TEST_F(OptionsTest, DefaultConfFile) {
     EXPECT_EQ(options_.log_disable(), false);
     EXPECT_EQ(options_.log_file(), "<stdout>");
     EXPECT_EQ(options_.log_files_count(), 10);
-    EXPECT_EQ(options_.log_file_size(), 10*1024*1024);
+    EXPECT_EQ(options_.log_file_size(), 1024*1024);
     EXPECT_EQ(options_.log_level(), "SYS_NOTICE");
     EXPECT_EQ(options_.log_local(), false);
     EXPECT_EQ(options_.ifmap_server_url(), "");
@@ -103,7 +103,7 @@ TEST_F(OptionsTest, DefaultConfFile) {
 TEST_F(OptionsTest, OverrideStringFromCommandLine) {
     int argc = 3;
     char *argv[argc];
-    char argv_0[] = "options_test";
+    char argv_0[] = "dns_options_test";
     char argv_1[] = "--conf_file=controller/src/dns/dns.conf";
     char argv_2[] = "--DEFAULT.log_file=test.log";
     argv[0] = argv_0;
@@ -126,7 +126,7 @@ TEST_F(OptionsTest, OverrideStringFromCommandLine) {
     EXPECT_EQ(options_.log_disable(), false);
     EXPECT_EQ(options_.log_file(), "test.log"); // Overridden from cmd line.
     EXPECT_EQ(options_.log_files_count(), 10);
-    EXPECT_EQ(options_.log_file_size(), 10*1024*1024);
+    EXPECT_EQ(options_.log_file_size(), 1024*1024);
     EXPECT_EQ(options_.log_level(), "SYS_NOTICE");
     EXPECT_EQ(options_.log_local(), false);
     EXPECT_EQ(options_.ifmap_server_url(), "");
@@ -139,7 +139,7 @@ TEST_F(OptionsTest, OverrideStringFromCommandLine) {
 TEST_F(OptionsTest, OverrideBooleanFromCommandLine) {
     int argc = 3;
     char *argv[argc];
-    char argv_0[] = "options_test";
+    char argv_0[] = "dns_options_test";
     char argv_1[] = "--conf_file=controller/src/dns/dns.conf";
     char argv_2[] = "--DEFAULT.test_mode";
     argv[0] = argv_0;
@@ -162,7 +162,7 @@ TEST_F(OptionsTest, OverrideBooleanFromCommandLine) {
     EXPECT_EQ(options_.log_disable(), false);
     EXPECT_EQ(options_.log_file(), "<stdout>");
     EXPECT_EQ(options_.log_files_count(), 10);
-    EXPECT_EQ(options_.log_file_size(), 10*1024*1024);
+    EXPECT_EQ(options_.log_file_size(), 1024*1024);
     EXPECT_EQ(options_.log_level(), "SYS_NOTICE");
     EXPECT_EQ(options_.log_local(), false);
     EXPECT_EQ(options_.ifmap_server_url(), "");
@@ -203,14 +203,14 @@ TEST_F(OptionsTest, CustomConfigFile) {
         "user=test-user\n";
 
     ofstream config_file;
-    config_file.open("/tmp/options_test_config_file.conf");
+    config_file.open("/tmp/dns_options_test_config_file.conf");
     config_file << config;
     config_file.close();
 
     int argc = 2;
     char *argv[argc];
-    char argv_0[] = "options_test";
-    char argv_1[] = "--conf_file=/tmp/options_test_config_file.conf";
+    char argv_0[] = "dns_options_test";
+    char argv_1[] = "--conf_file=/tmp/dns_options_test_config_file.conf";
     argv[0] = argv_0;
     argv[1] = argv_1;
 
@@ -220,7 +220,7 @@ TEST_F(OptionsTest, CustomConfigFile) {
     EXPECT_EQ(options_.collector_server(), "3.4.5.6");
     EXPECT_EQ(options_.collector_port(), 100);
     EXPECT_EQ(options_.config_file(),
-              "/tmp/options_test_config_file.conf");
+              "/tmp/dns_options_test_config_file.conf");
     EXPECT_EQ(options_.discovery_server(), "1.0.0.1");
     EXPECT_EQ(options_.discovery_port(), 100);
     EXPECT_EQ(options_.hostname(), "test");
@@ -271,14 +271,14 @@ TEST_F(OptionsTest, CustomConfigFileAndOverrideFromCommandLine) {
         "user=test-user\n";
 
     ofstream config_file;
-    config_file.open("/tmp/options_test_config_file.conf");
+    config_file.open("/tmp/dns_options_test_config_file.conf");
     config_file << config;
     config_file.close();
 
     int argc = 5;
     char *argv[argc];
-    char argv_0[] = "options_test";
-    char argv_1[] = "--conf_file=/tmp/options_test_config_file.conf";
+    char argv_0[] = "dns_options_test";
+    char argv_1[] = "--conf_file=/tmp/dns_options_test_config_file.conf";
     char argv_2[] = "--DEFAULT.log_file=new_test.log";
     char argv_3[] = "--DEFAULT.log_local";
     char argv_4[] = "--COLLECTOR.port=1000";
@@ -294,7 +294,7 @@ TEST_F(OptionsTest, CustomConfigFileAndOverrideFromCommandLine) {
     EXPECT_EQ(options_.collector_server(), "3.4.5.6");
     EXPECT_EQ(options_.collector_port(), 1000);
     EXPECT_EQ(options_.config_file(),
-              "/tmp/options_test_config_file.conf");
+              "/tmp/dns_options_test_config_file.conf");
     EXPECT_EQ(options_.discovery_server(), "1.0.0.1");
     EXPECT_EQ(options_.discovery_port(), 100);
     EXPECT_EQ(options_.hostname(), "test");


### PR DESCRIPTION
```
Configuration format changes for the dns
control-node now take configuration in the standard ini format.
Default configuration file is read off /etc/contrail/dns.conf

One can override the values from the config file through command line option
as well. e.g. --DEFAULT.log_level=DEBUG

Use --help to see various options available. contrail-control package also
places the default config file under /etc/contrail/dns.conf

When changes are made to the configuration file, the process must be _restarted_
to take effect. (service supervisord-control restart).
```
