### PR TITLE
cdb performance improvements in vizd

### DIFF
--- a/src/analytics/collector.h
+++ b/src/analytics/collector.h
@@ -56,10 +56,23 @@ public:
     void GetGeneratorSandeshStatsInfo(std::vector<ModuleServerState> &genlist);
     bool SendRemote(const std::string& destination,
             const std::string &dec_sandesh);
-    void SetDbQueueWaterMarkInfo(DbHandler::DbQueueWaterMarkInfo &wm);
+
+    struct QueueType {
+        enum type {
+            Db,
+            Sm,
+        };
+    };
+    void SetDbQueueWaterMarkInfo(Sandesh::QueueWaterMarkInfo &wm);
     void ResetDbQueueWaterMarkInfo();
     void GetDbQueueWaterMarkInfo(
-        std::vector<DbHandler::DbQueueWaterMarkInfo> &wm_info) const;
+        std::vector<Sandesh::QueueWaterMarkInfo> &wm_info) const;
+    void SetSmQueueWaterMarkInfo(Sandesh::QueueWaterMarkInfo &wm);
+    void ResetSmQueueWaterMarkInfo();
+    void GetSmQueueWaterMarkInfo(
+        std::vector<Sandesh::QueueWaterMarkInfo> &wm_info) const;
+    void GetQueueWaterMarkInfo(QueueType::type type,
+        std::vector<Sandesh::QueueWaterMarkInfo> &wm_info) const;
 
     OpServerProxy * GetOSP() const { return osp_; }
     EventManager * event_manager() const { return evm_; }
@@ -84,11 +97,16 @@ public:
     static DiscoveryServiceClient *GetCollectorDiscoveryServiceClient() {
         return ds_client_;
     }
+
 protected:
     virtual TcpSession *AllocSession(Socket *socket);
     virtual void DisconnectSession(SandeshSession *session);
 
 private:
+    void SetQueueWaterMarkInfo(QueueType::type type,
+        Sandesh::QueueWaterMarkInfo &wm);
+    void ResetQueueWaterMarkInfo(QueueType::type type);
+
     void inline increment_no_session_error() {
         stats_.no_session_error++;
     }
@@ -124,11 +142,13 @@ private:
     tbb::mutex rand_mutex_;
     boost::uuids::random_generator umn_gen_;
     CollectorStats stats_;
-    std::vector<DbHandler::DbQueueWaterMarkInfo> db_queue_wm_info_;
+    std::vector<Sandesh::QueueWaterMarkInfo> db_queue_wm_info_;
+    std::vector<Sandesh::QueueWaterMarkInfo> sm_queue_wm_info_;
     static std::string prog_name_;
     static std::string self_ip_;
     static bool task_policy_set_;
-    static const std::vector<DbHandler::DbQueueWaterMarkInfo> kDbQueueWaterMarkInfo;
+    static const std::vector<Sandesh::QueueWaterMarkInfo> kDbQueueWaterMarkInfo;
+    static const std::vector<Sandesh::QueueWaterMarkInfo> kSmQueueWaterMarkInfo;
     static const int kDefaultSessionBufferSize = 16 * 1024;
 
     static DiscoveryServiceClient *ds_client_;

--- a/src/analytics/collector_uve.sandesh
+++ b/src/analytics/collector_uve.sandesh
@@ -63,6 +63,7 @@ struct ModuleServerState {
     12: optional sandesh_uve.SandeshGeneratorStats  sm_msg_stats
     13: optional string                    db_drop_level
     14: optional u64                       db_msg_dropped
+    15: optional string                    sm_drop_level
 }
 
 uve sandesh SandeshModuleServerTrace {
@@ -162,18 +163,30 @@ request sandesh DbQueueParamsReset {
 request sandesh DbQueueParamsStatus {
 }
 
-struct DbQueueParams {
+request sandesh SmQueueParamsSet {
+    1: optional bool high;
+    2: optional u32 queue_count;
+    3: optional string drop_level;
+}    
+
+request sandesh SmQueueParamsReset {
+}
+
+request sandesh SmQueueParamsStatus {
+}
+
+struct QueueParams {
     1: bool high;
     2: u32 queue_count;
     3: string drop_level;
 }
 
-response sandesh DbQueueParamsError {
+response sandesh QueueParamsError {
     1: string error;
 }
 
-response sandesh DbQueueParamsResponse {
-    1: list<DbQueueParams> info;
+response sandesh QueueParamsResponse {
+    1: list<QueueParams> info;
 }
 
 struct SandeshMessageInfo {

--- a/src/analytics/db_handler.h
+++ b/src/analytics/db_handler.h
@@ -81,8 +81,7 @@ public:
     bool GetStats(uint64_t &queue_count, uint64_t &enqueues,
         std::string &drop_level, uint64_t &msg_dropped) const;
 
-    typedef boost::tuple<size_t, SandeshLevel::type, bool> DbQueueWaterMarkInfo;
-    void SetDbQueueWaterMarkInfo(DbQueueWaterMarkInfo &wm);
+    void SetDbQueueWaterMarkInfo(Sandesh::QueueWaterMarkInfo &wm);
     void ResetDbQueueWaterMarkInfo();
 
 private:

--- a/src/analytics/generator.h
+++ b/src/analytics/generator.h
@@ -90,6 +90,7 @@ public:
     void ConnectSession(VizSession *vsession, SandeshStateMachine *state_machine);
 
     bool GetSandeshStateMachineQueueCount(uint64_t &queue_count) const;
+    bool GetSandeshStateMachineDropLevel(std::string &drop_level) const;
     bool GetSandeshStateMachineStats(SandeshStateMachineStats &sm_stats,
                                      SandeshGeneratorStats &sm_msg_stats) const;
     bool GetDbStats(uint64_t &queue_count, uint64_t &enqueues,
@@ -107,8 +108,10 @@ public:
     const std::string State() const;
 
     void GetGeneratorInfo(ModuleServerState &genlist) const;
-    void SetDbQueueWaterMarkInfo(DbHandler::DbQueueWaterMarkInfo &wm);
+    void SetDbQueueWaterMarkInfo(Sandesh::QueueWaterMarkInfo &wm);
     void ResetDbQueueWaterMarkInfo();
+    void SetSmQueueWaterMarkInfo(Sandesh::QueueWaterMarkInfo &wm);
+    void ResetSmQueueWaterMarkInfo();
     void StartDbifReinit();
     virtual DbHandler *GetDbHandler() { return db_handler_.get (); }
 

--- a/src/analytics/test/db_handler_test.cc
+++ b/src/analytics/test/db_handler_test.cc
@@ -4,7 +4,8 @@
 
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/assign/list_of.hpp>
+#include <boost/assign/ptr_list_of.hpp>
+#include <boost/uuid/uuid.hpp>
 #include "testing/gunit.h"
 #include "base/logging.h"
 #include "sandesh/sandesh_types.h"
@@ -14,11 +15,11 @@
 #include "../viz_constants.h"
 #include "../db_handler.h"
 #include "cdb_if_mock.h"
-
 #include "../vizd_table_desc.h"
 
 using ::testing::Return;
 using ::testing::Field;
+using ::testing::Property;
 using ::testing::AnyOf;
 using ::testing::AnyNumber;
 using ::testing::_;
@@ -27,6 +28,7 @@ using ::testing::ElementsAre;
 using ::testing::Pointee;
 using ::testing::ElementsAreArray;
 using ::testing::Matcher;
+using ::testing::ByRef;
 using namespace pugi;
 
 class DbHandlerTest : public ::testing::Test {
@@ -120,6 +122,9 @@ TEST_F(DbHandlerTest, MessageTableOnlyInsertTest) {
 
     hdr.set_Source("127.0.0.1");
     hdr.set_Module("VizdTest");
+    hdr.set_InstanceId("Test");
+    hdr.set_NodeType("Test");
+    hdr.set_Timestamp(UTCTimestampUsec());
     std::string messagetype("SandeshAsyncTest2");
     std::string xmlmessage = "<SandeshAsyncTest2 type=\"sandesh\"><file type=\"string\" identifier=\"-32768\">src/analytics/test/viz_collector_test.cc</file><line type=\"i32\" identifier=\"-32767\">80</line><f1 type=\"struct\" identifier=\"1\"><SAT2_struct><f1 type=\"string\" identifier=\"1\">sat2string101</f1><f2 type=\"i32\" identifier=\"2\">101</f2></SAT2_struct></f1><f2 type=\"i32\" identifier=\"2\">101</f2></SandeshAsyncTest2>";
 
@@ -134,26 +139,33 @@ TEST_F(DbHandlerTest, MessageTableOnlyInsertTest) {
     GenDb::DbDataValueVec rowkey;
     rowkey.push_back(unm);
 
-    Matcher<GenDb::NewCol> msg_table_expected_vector[] = {
-        GenDb::NewCol(g_viz_constants.SOURCE, hdr.get_Source()),
-        _,
-        GenDb::NewCol(g_viz_constants.MODULE, hdr.get_Module()),
-        _,
-        _,
-        _,
-        GenDb::NewCol(g_viz_constants.MESSAGE_TYPE, messagetype),
-        _,
-        _,
-        _,
-        GenDb::NewCol(g_viz_constants.DATA, xmlmessage) };
+    boost::ptr_vector<GenDb::NewCol> msg_table_expected_vector = 
+        boost::assign::ptr_list_of<GenDb::NewCol>
+        (GenDb::NewCol(g_viz_constants.SOURCE, hdr.get_Source()))
+        (GenDb::NewCol(g_viz_constants.NAMESPACE, std::string()))
+        (GenDb::NewCol(g_viz_constants.MODULE, hdr.get_Module()))
+        (GenDb::NewCol(g_viz_constants.INSTANCE_ID, hdr.get_InstanceId()))
+        (GenDb::NewCol(g_viz_constants.NODE_TYPE, hdr.get_NodeType()))
+        (GenDb::NewCol(g_viz_constants.TIMESTAMP,
+            static_cast<uint64_t>(hdr.get_Timestamp())))
+        (GenDb::NewCol(g_viz_constants.CATEGORY, std::string()))
+        (GenDb::NewCol(g_viz_constants.LEVEL,
+            static_cast<uint32_t>(0)))
+        (GenDb::NewCol(g_viz_constants.MESSAGE_TYPE, messagetype))
+        (GenDb::NewCol(g_viz_constants.SEQUENCE_NUM,
+            static_cast<uint32_t>(0)))
+        (GenDb::NewCol(g_viz_constants.VERSION,
+            static_cast<uint32_t>(0)))
+        (GenDb::NewCol(g_viz_constants.SANDESH_TYPE,
+            static_cast<uint8_t>(0)))
+        (GenDb::NewCol(g_viz_constants.DATA, xmlmessage));
 
     EXPECT_CALL(*dbif_mock(),
             NewDb_AddColumnProxy(
                 Pointee(
                     AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.COLLECTOR_GLOBAL_TABLE),
                         Field(&GenDb::ColList::rowkey_, rowkey),
-                        Field(&GenDb::ColList::columns_,
-                            ElementsAreArray(msg_table_expected_vector))))))
+                        Field(&GenDb::ColList::columns_, msg_table_expected_vector)))))
         .Times(1)
         .WillOnce(Return(true));
 
@@ -169,13 +181,12 @@ TEST_F(DbHandlerTest, MessageIndexTableInsertTest) {
     hdr.set_Timestamp(UTCTimestampUsec());
     boost::uuids::uuid unm(rgen_());
 
-    DbDataValueVec colname;
-    colname.push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
-    DbDataValueVec colvalue;
-    colvalue.push_back(unm);
-    Matcher<GenDb::NewCol> idx_expected_vector[] = {
-        GenDb::NewCol(colname, colvalue)
-    };
+    DbDataValueVec *colname(new DbDataValueVec(1,
+        (uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask)));
+    DbDataValueVec *colvalue(new DbDataValueVec(1, unm));
+    boost::ptr_vector<GenDb::NewCol> idx_expected_vector =
+        boost::assign::ptr_list_of<GenDb::NewCol> 
+        (GenDb::NewCol(colname, colvalue));
 
     GenDb::DbDataValueVec src_idx_rowkey;
     src_idx_rowkey.push_back((uint32_t)(hdr.get_Timestamp() >> g_viz_constants.RowTimeInBits));
@@ -186,7 +197,7 @@ TEST_F(DbHandlerTest, MessageIndexTableInsertTest) {
                     AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.MESSAGE_TABLE_SOURCE),
                         Field(&GenDb::ColList::rowkey_, src_idx_rowkey),
                         Field(&GenDb::ColList::columns_,
-                            ElementsAreArray(idx_expected_vector))))))
+                            idx_expected_vector)))))
         .Times(1)
         .WillOnce(Return(true));
 
@@ -199,6 +210,9 @@ TEST_F(DbHandlerTest, MessageTableInsertTest) {
     hdr.set_Source("127.0.0.1");
     hdr.set_Module("VizdTest");
     std::string messagetype("SandeshAsyncTest2");
+    hdr.set_InstanceId("Test");
+    hdr.set_NodeType("Test");
+    hdr.set_Timestamp(UTCTimestampUsec());
     std::string xmlmessage = "<SandeshAsyncTest2 type=\"sandesh\"><file type=\"string\" identifier=\"-32768\">src/analytics/test/viz_collector_test.cc</file><line type=\"i32\" identifier=\"-32767\">80</line><f1 type=\"struct\" identifier=\"1\"><SAT2_struct><f1 type=\"string\" identifier=\"1\">sat2string101</f1><f2 type=\"i32\" identifier=\"2\">101</f2></SAT2_struct></f1><f2 type=\"i32\" identifier=\"2\">101</f2></SandeshAsyncTest2>";
 
     SandeshXMLMessageTest *msg = dynamic_cast<SandeshXMLMessageTest *>(
@@ -212,18 +226,26 @@ TEST_F(DbHandlerTest, MessageTableInsertTest) {
     GenDb::DbDataValueVec rowkey;
     rowkey.push_back(unm);
 
-    Matcher<GenDb::NewCol> msg_table_expected_vector[] = {
-        GenDb::NewCol(g_viz_constants.SOURCE, hdr.get_Source()),
-        _,
-        GenDb::NewCol(g_viz_constants.MODULE, hdr.get_Module()),
-        _,
-        _,
-        _,
-        GenDb::NewCol(g_viz_constants.MESSAGE_TYPE, messagetype),
-        _,
-        _,
-        _,
-        GenDb::NewCol(g_viz_constants.DATA, xmlmessage) };
+    boost::ptr_vector<GenDb::NewCol> msg_table_expected_vector = 
+        boost::assign::ptr_list_of<GenDb::NewCol>
+        (GenDb::NewCol(g_viz_constants.SOURCE, hdr.get_Source()))
+        (GenDb::NewCol(g_viz_constants.NAMESPACE, std::string()))
+        (GenDb::NewCol(g_viz_constants.MODULE, hdr.get_Module()))
+        (GenDb::NewCol(g_viz_constants.INSTANCE_ID, hdr.get_InstanceId()))
+        (GenDb::NewCol(g_viz_constants.NODE_TYPE, hdr.get_NodeType()))
+        (GenDb::NewCol(g_viz_constants.TIMESTAMP,
+            static_cast<uint64_t>(hdr.get_Timestamp())))
+        (GenDb::NewCol(g_viz_constants.CATEGORY, std::string()))
+        (GenDb::NewCol(g_viz_constants.LEVEL,
+            static_cast<uint32_t>(0)))
+        (GenDb::NewCol(g_viz_constants.MESSAGE_TYPE, messagetype))
+        (GenDb::NewCol(g_viz_constants.SEQUENCE_NUM,
+            static_cast<uint32_t>(0)))
+        (GenDb::NewCol(g_viz_constants.VERSION,
+            static_cast<uint32_t>(0)))
+        (GenDb::NewCol(g_viz_constants.SANDESH_TYPE,
+            static_cast<uint8_t>(0)))
+        (GenDb::NewCol(g_viz_constants.DATA, xmlmessage));
 
     EXPECT_CALL(*dbif_mock(),
             NewDb_AddColumnProxy(
@@ -231,17 +253,16 @@ TEST_F(DbHandlerTest, MessageTableInsertTest) {
                     AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.COLLECTOR_GLOBAL_TABLE),
                         Field(&GenDb::ColList::rowkey_, rowkey),
                         Field(&GenDb::ColList::columns_,
-                            ElementsAreArray(msg_table_expected_vector))))))
+                            msg_table_expected_vector)))))
         .Times(1)
         .WillOnce(Return(true));
 
-    DbDataValueVec colname;
-    colname.push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
-    DbDataValueVec colvalue;
-    colvalue.push_back(unm);
-    Matcher<GenDb::NewCol> idx_expected_vector[] = {
-        GenDb::NewCol(colname, colvalue)
-    };
+    DbDataValueVec *colname(new DbDataValueVec(1,
+        (uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask)));
+    DbDataValueVec *colvalue(new DbDataValueVec(1, unm));
+    boost::ptr_vector<GenDb::NewCol> idx_expected_vector = 
+        boost::assign::ptr_list_of<GenDb::NewCol>
+        (GenDb::NewCol(colname, colvalue));
 
     GenDb::DbDataValueVec src_idx_rowkey;
     src_idx_rowkey.push_back((uint32_t)(hdr.get_Timestamp() >> g_viz_constants.RowTimeInBits));
@@ -252,7 +273,7 @@ TEST_F(DbHandlerTest, MessageTableInsertTest) {
                     AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.MESSAGE_TABLE_SOURCE),
                         Field(&GenDb::ColList::rowkey_, src_idx_rowkey),
                         Field(&GenDb::ColList::columns_,
-                            ElementsAreArray(idx_expected_vector))))))
+                            idx_expected_vector)))))
         .Times(1)
         .WillOnce(Return(true));
 
@@ -265,7 +286,7 @@ TEST_F(DbHandlerTest, MessageTableInsertTest) {
                     AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.MESSAGE_TABLE_MODULE_ID),
                         Field(&GenDb::ColList::rowkey_, mod_idx_rowkey),
                         Field(&GenDb::ColList::columns_,
-                            ElementsAreArray(idx_expected_vector))))))
+                            idx_expected_vector)))))
         .Times(1)
         .WillOnce(Return(true));
 
@@ -278,7 +299,7 @@ TEST_F(DbHandlerTest, MessageTableInsertTest) {
                     AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.MESSAGE_TABLE_CATEGORY),
                         Field(&GenDb::ColList::rowkey_, cat_idx_rowkey),
                         Field(&GenDb::ColList::columns_,
-                            ElementsAreArray(idx_expected_vector))))))
+                            idx_expected_vector)))))
         .Times(1)
         .WillOnce(Return(true));
 
@@ -291,7 +312,7 @@ TEST_F(DbHandlerTest, MessageTableInsertTest) {
                     AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.MESSAGE_TABLE_MESSAGE_TYPE),
                         Field(&GenDb::ColList::rowkey_, msgtype_idx_rowkey),
                         Field(&GenDb::ColList::columns_,
-                            ElementsAreArray(idx_expected_vector))))))
+                            idx_expected_vector)))))
         .Times(1)
         .WillOnce(Return(true));
 
@@ -303,7 +324,7 @@ TEST_F(DbHandlerTest, MessageTableInsertTest) {
                     AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.MESSAGE_TABLE_TIMESTAMP),
                         Field(&GenDb::ColList::rowkey_, ts_idx_rowkey),
                         Field(&GenDb::ColList::columns_,
-                            ElementsAreArray(idx_expected_vector))))))
+                            idx_expected_vector)))))
         .Times(1)
         .WillOnce(Return(true));
 
@@ -330,13 +351,12 @@ TEST_F(DbHandlerTest, ObjectTableInsertTest) {
     std::string rowkey_str("ObjectTableInsertTestRowkey");
 
       {
-        DbDataValueVec colname;
-        colname.push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
-        DbDataValueVec colvalue;
-        colvalue.push_back(unm);
-        Matcher<GenDb::NewCol> expected_vector[] = {
-            GenDb::NewCol(colname, colvalue)
-        };
+        DbDataValueVec *colname(new DbDataValueVec(1,
+            (uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask)));
+        DbDataValueVec *colvalue(new DbDataValueVec(1, unm));
+        boost::ptr_vector<GenDb::NewCol> expected_vector = 
+            boost::assign::ptr_list_of<GenDb::NewCol>
+            (GenDb::NewCol(colname, colvalue));
 
         GenDb::DbDataValueVec rowkey;
         rowkey.push_back((uint32_t)(hdr.get_Timestamp() >> g_viz_constants.RowTimeInBits));
@@ -347,19 +367,19 @@ TEST_F(DbHandlerTest, ObjectTableInsertTest) {
                         AllOf(Field(&GenDb::ColList::cfname_, "ObjectTableInsertTest"),
                             Field(&GenDb::ColList::rowkey_, rowkey),
                             Field(&GenDb::ColList::columns_,
-                                ElementsAreArray(expected_vector))))))
+                                expected_vector)))))
             .Times(1)
             .WillOnce(Return(true));
       }
 
       {
-        DbDataValueVec colname;
-        colname.push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
-        DbDataValueVec colvalue;
-        colvalue.push_back("ObjectTableInsertTestRowkey");
-        Matcher<GenDb::NewCol> expected_vector[] = {
-            GenDb::NewCol(colname, colvalue)
-        };
+        DbDataValueVec *colname(new DbDataValueVec(1,
+            (uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask)));
+        DbDataValueVec *colvalue(new DbDataValueVec(1,
+            "ObjectTableInsertTestRowkey"));
+        boost::ptr_vector<GenDb::NewCol> expected_vector =
+            boost::assign::ptr_list_of<GenDb::NewCol>
+            (GenDb::NewCol(colname, colvalue));
 
         GenDb::DbDataValueVec rowkey;
         rowkey.push_back((uint32_t)(hdr.get_Timestamp() >> g_viz_constants.RowTimeInBits));
@@ -370,7 +390,7 @@ TEST_F(DbHandlerTest, ObjectTableInsertTest) {
                         AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.OBJECT_VALUE_TABLE),
                             Field(&GenDb::ColList::rowkey_, rowkey),
                             Field(&GenDb::ColList::columns_,
-                                ElementsAreArray(expected_vector))))))
+                                expected_vector)))))
             .Times(1)
             .WillOnce(Return(true));
       }
@@ -378,16 +398,17 @@ TEST_F(DbHandlerTest, ObjectTableInsertTest) {
       {
         boost::uuids::string_generator gen;
         boost::uuids::uuid unm_allf = gen(std::string("ffffffffffffffffffffffffffffffff"));
-        DbDataValueVec colname;
-        colname.push_back("ObjectTableInsertTest:Objecttype");
-        colname.push_back("");
-        colname.push_back((uint32_t)0);
-        colname.push_back(unm_allf);
-        DbDataValueVec colvalue;
-        colvalue.push_back("{\"fields.value\":\"ObjectTableInsertTestRowkey\",\"name\":\"ObjectTableInsertTest:Objecttype\"}");
-        Matcher<GenDb::NewCol> expected_vector[] = {
-            GenDb::NewCol(colname, colvalue)
-        };
+        DbDataValueVec *colname(new DbDataValueVec);
+        colname->reserve(4);
+        colname->push_back("ObjectTableInsertTest:Objecttype");
+        colname->push_back("");
+        colname->push_back((uint32_t)0);
+        colname->push_back(unm_allf);
+        DbDataValueVec *colvalue(new DbDataValueVec(1,
+            "{\"fields.value\":\"ObjectTableInsertTestRowkey\",\"name\":\"ObjectTableInsertTest:Objecttype\"}"));
+        boost::ptr_vector<GenDb::NewCol> expected_vector =
+            boost::assign::ptr_list_of<GenDb::NewCol>
+            (GenDb::NewCol(colname, colvalue));
 
         GenDb::DbDataValueVec rowkey;
         rowkey.push_back((uint32_t)(hdr.get_Timestamp() >> g_viz_constants.RowTimeInBits));
@@ -400,7 +421,7 @@ TEST_F(DbHandlerTest, ObjectTableInsertTest) {
                         AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.STATS_TABLE_BY_STR_STR_TAG),
                             Field(&GenDb::ColList::rowkey_, rowkey),
                             Field(&GenDb::ColList::columns_,
-                                ElementsAreArray(expected_vector))))))
+                                expected_vector)))))
             .Times(1)
             .WillOnce(Return(true));
       }
@@ -408,16 +429,17 @@ TEST_F(DbHandlerTest, ObjectTableInsertTest) {
       {
         boost::uuids::string_generator gen;
         boost::uuids::uuid unm_allf = gen(std::string("ffffffffffffffffffffffffffffffff"));
-        DbDataValueVec colname;
-        colname.push_back("ObjectTableInsertTestRowkey");
-        colname.push_back("");
-        colname.push_back((uint32_t)0);
-        colname.push_back(unm_allf);
-        DbDataValueVec colvalue;
-        colvalue.push_back("{\"fields.value\":\"ObjectTableInsertTestRowkey\",\"name\":\"ObjectTableInsertTest:Objecttype\"}");
-        Matcher<GenDb::NewCol> expected_vector[] = {
-            GenDb::NewCol(colname, colvalue)
-        };
+        DbDataValueVec *colname(new DbDataValueVec);
+        colname->reserve(4);
+        colname->push_back("ObjectTableInsertTestRowkey");
+        colname->push_back("");
+        colname->push_back((uint32_t)0);
+        colname->push_back(unm_allf);
+        DbDataValueVec *colvalue(new DbDataValueVec(1,
+            "{\"fields.value\":\"ObjectTableInsertTestRowkey\",\"name\":\"ObjectTableInsertTest:Objecttype\"}"));
+        boost::ptr_vector<GenDb::NewCol> expected_vector =
+            boost::assign::ptr_list_of<GenDb::NewCol> 
+            (GenDb::NewCol(colname, colvalue));
 
         GenDb::DbDataValueVec rowkey;
         rowkey.push_back((uint32_t)(hdr.get_Timestamp() >> g_viz_constants.RowTimeInBits));
@@ -430,7 +452,7 @@ TEST_F(DbHandlerTest, ObjectTableInsertTest) {
                         AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.STATS_TABLE_BY_STR_STR_TAG),
                             Field(&GenDb::ColList::rowkey_, rowkey),
                             Field(&GenDb::ColList::columns_,
-                                ElementsAreArray(expected_vector))))))
+                                expected_vector)))))
             .Times(1)
             .WillOnce(Return(true));
       }
@@ -458,9 +480,6 @@ TEST_F(DbHandlerTest, FlowTableInsertTest) {
     boost::uuids::uuid flowu = boost::uuids::string_generator()(flowu_str);
 
       {
-        Matcher<GenDb::NewCol> expected_vector[] = {
-        };
-
         GenDb::DbDataValueVec rowkey;
         rowkey.push_back(flowu);
 
@@ -473,30 +492,32 @@ TEST_F(DbHandlerTest, FlowTableInsertTest) {
             .WillOnce(Return(true));
       }
 
-    GenDb::DbDataValueVec colvalue;
-    colvalue.push_back((uint64_t)0); //bytes
-    colvalue.push_back((uint64_t)0); //pkts
-    colvalue.push_back((uint8_t)0); //dir
-    colvalue.push_back(flowu); //flowuuid
-    colvalue.push_back(hdr.get_Source()); //vrouter
-    colvalue.push_back("default-domain:demo:vn1"); //svn
-    colvalue.push_back("default-domain:demo:vn0"); //dvn
-    colvalue.push_back((uint32_t)-1062731011); //sip
-    colvalue.push_back((uint32_t)-1062731267); //dip
-    colvalue.push_back((uint8_t)6); //prot
-    colvalue.push_back((uint16_t)5201); //sport
-    colvalue.push_back((uint16_t)-24590); //dport
-    colvalue.push_back(""); //json
+    GenDb::DbDataValueVec ocolvalue;
+    ocolvalue.push_back((uint64_t)0); //bytes
+    ocolvalue.push_back((uint64_t)0); //pkts
+    ocolvalue.push_back((uint8_t)0); //dir
+    ocolvalue.push_back(flowu); //flowuuid
+    ocolvalue.push_back(hdr.get_Source()); //vrouter
+    ocolvalue.push_back("default-domain:demo:vn1"); //svn
+    ocolvalue.push_back("default-domain:demo:vn0"); //dvn
+    ocolvalue.push_back((uint32_t)-1062731011); //sip
+    ocolvalue.push_back((uint32_t)-1062731267); //dip
+    ocolvalue.push_back((uint8_t)6); //prot
+    ocolvalue.push_back((uint16_t)5201); //sport
+    ocolvalue.push_back((uint16_t)-24590); //dport
+    ocolvalue.push_back(""); //json
 
       {
-        GenDb::DbDataValueVec colname;
-        colname.push_back("default-domain:demo:vn1");
-        colname.push_back((uint32_t)-1062731011);
-        colname.push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
-        colname.push_back(flowu);
-        Matcher<GenDb::NewCol> expected_vector[] = {
-            GenDb::NewCol(colname, colvalue)
-        };
+        GenDb::DbDataValueVec *colname(new GenDb::DbDataValueVec);
+        colname->reserve(4);
+        colname->push_back("default-domain:demo:vn1");
+        colname->push_back((uint32_t)-1062731011);
+        colname->push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
+        colname->push_back(flowu);
+        GenDb::DbDataValueVec *colvalue(new GenDb::DbDataValueVec(ocolvalue));
+        boost::ptr_vector<GenDb::NewCol> expected_vector =
+            boost::assign::ptr_list_of<GenDb::NewCol> 
+            (GenDb::NewCol(colname, colvalue));
 
         GenDb::DbDataValueVec rowkey;
         rowkey.push_back((uint32_t)(hdr.get_Timestamp() >> g_viz_constants.RowTimeInBits));
@@ -510,19 +531,21 @@ TEST_F(DbHandlerTest, FlowTableInsertTest) {
                         AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.FLOW_TABLE_SVN_SIP),
                             Field(&GenDb::ColList::rowkey_, rowkey),
                             Field(&GenDb::ColList::columns_,
-                                ElementsAreArray(expected_vector))))))
+                                expected_vector)))))
             .Times(1)
             .WillOnce(Return(true));
       }
       {
-        GenDb::DbDataValueVec colname;
-        colname.push_back("default-domain:demo:vn0");
-        colname.push_back((uint32_t)-1062731267);
-        colname.push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
-        colname.push_back(flowu);
-        Matcher<GenDb::NewCol> expected_vector[] = {
-            GenDb::NewCol(colname, colvalue)
-        };
+        GenDb::DbDataValueVec *colname(new GenDb::DbDataValueVec);
+        colname->reserve(4);
+        colname->push_back("default-domain:demo:vn0");
+        colname->push_back((uint32_t)-1062731267);
+        colname->push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
+        colname->push_back(flowu);
+        GenDb::DbDataValueVec *colvalue(new GenDb::DbDataValueVec(ocolvalue));
+        boost::ptr_vector<GenDb::NewCol> expected_vector =
+            boost::assign::ptr_list_of<GenDb::NewCol>
+            (GenDb::NewCol(colname, colvalue));
 
         GenDb::DbDataValueVec rowkey;
         rowkey.push_back((uint32_t)(hdr.get_Timestamp() >> g_viz_constants.RowTimeInBits));
@@ -536,19 +559,21 @@ TEST_F(DbHandlerTest, FlowTableInsertTest) {
                         AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.FLOW_TABLE_DVN_DIP),
                             Field(&GenDb::ColList::rowkey_, rowkey),
                             Field(&GenDb::ColList::columns_,
-                                ElementsAreArray(expected_vector))))))
+                                expected_vector)))))
             .Times(1)
             .WillOnce(Return(true));
       }
       {
-        GenDb::DbDataValueVec colname;
-        colname.push_back((uint8_t)6);
-        colname.push_back((uint16_t)5201);
-        colname.push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
-        colname.push_back(flowu);
-        Matcher<GenDb::NewCol> expected_vector[] = {
-            GenDb::NewCol(colname, colvalue)
-        };
+        GenDb::DbDataValueVec *colname(new GenDb::DbDataValueVec);
+        colname->reserve(4);
+        colname->push_back((uint8_t)6);
+        colname->push_back((uint16_t)5201);
+        colname->push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
+        colname->push_back(flowu);
+        GenDb::DbDataValueVec *colvalue(new GenDb::DbDataValueVec(ocolvalue));
+        boost::ptr_vector<GenDb::NewCol> expected_vector =
+            boost::assign::ptr_list_of<GenDb::NewCol>
+            (GenDb::NewCol(colname, colvalue));
 
         GenDb::DbDataValueVec rowkey;
         rowkey.push_back((uint32_t)(hdr.get_Timestamp() >> g_viz_constants.RowTimeInBits));
@@ -562,20 +587,22 @@ TEST_F(DbHandlerTest, FlowTableInsertTest) {
                         AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.FLOW_TABLE_PROT_SP),
                             Field(&GenDb::ColList::rowkey_, rowkey),
                             Field(&GenDb::ColList::columns_,
-                                ElementsAreArray(expected_vector))))))
+                                expected_vector)))))
             .Times(1)
             .WillOnce(Return(true));
       }
 
       {
-        GenDb::DbDataValueVec colname;
-        colname.push_back((uint8_t)6);
-        colname.push_back((uint16_t)-24590);
-        colname.push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
-        colname.push_back(flowu);
-        Matcher<GenDb::NewCol> expected_vector[] = {
-            GenDb::NewCol(colname, colvalue)
-        };
+        GenDb::DbDataValueVec *colname(new GenDb::DbDataValueVec);
+        colname->reserve(4);
+        colname->push_back((uint8_t)6);
+        colname->push_back((uint16_t)-24590);
+        colname->push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
+        colname->push_back(flowu);
+        GenDb::DbDataValueVec *colvalue(new GenDb::DbDataValueVec(ocolvalue));
+        boost::ptr_vector<GenDb::NewCol> expected_vector =
+            boost::assign::ptr_list_of<GenDb::NewCol>
+            (GenDb::NewCol(colname, colvalue));
 
         GenDb::DbDataValueVec rowkey;
         rowkey.push_back((uint32_t)(hdr.get_Timestamp() >> g_viz_constants.RowTimeInBits));
@@ -589,19 +616,21 @@ TEST_F(DbHandlerTest, FlowTableInsertTest) {
                         AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.FLOW_TABLE_PROT_DP),
                             Field(&GenDb::ColList::rowkey_, rowkey),
                             Field(&GenDb::ColList::columns_,
-                                ElementsAreArray(expected_vector))))))
+                                expected_vector)))))
             .Times(1)
             .WillOnce(Return(true));
       }
 
       {
-        GenDb::DbDataValueVec colname;
-        colname.push_back(hdr.get_Source()); //vrouter
-        colname.push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
-        colname.push_back(flowu);
-        Matcher<GenDb::NewCol> expected_vector[] = {
-            GenDb::NewCol(colname, colvalue)
-        };
+        GenDb::DbDataValueVec *colname(new GenDb::DbDataValueVec);
+        colname->reserve(4);
+        colname->push_back(hdr.get_Source()); //vrouter
+        colname->push_back((uint32_t)(hdr.get_Timestamp() & g_viz_constants.RowTimeInMask));
+        colname->push_back(flowu);
+        GenDb::DbDataValueVec *colvalue(new GenDb::DbDataValueVec(ocolvalue));
+        boost::ptr_vector<GenDb::NewCol> expected_vector =
+            boost::assign::ptr_list_of<GenDb::NewCol>
+            (GenDb::NewCol(colname, colvalue));
 
         GenDb::DbDataValueVec rowkey;
         rowkey.push_back((uint32_t)(hdr.get_Timestamp() >> g_viz_constants.RowTimeInBits));
@@ -615,7 +644,7 @@ TEST_F(DbHandlerTest, FlowTableInsertTest) {
                         AllOf(Field(&GenDb::ColList::cfname_, g_viz_constants.FLOW_TABLE_VROUTER),
                             Field(&GenDb::ColList::rowkey_, rowkey),
                             Field(&GenDb::ColList::columns_,
-                                ElementsAreArray(expected_vector))))))
+                                expected_vector)))))
             .Times(1)
             .WillOnce(Return(true));
       }
@@ -623,6 +652,83 @@ TEST_F(DbHandlerTest, FlowTableInsertTest) {
     db_handler()->FlowTableInsert(msg->GetMessageNode(),
         msg->GetHeader());
     delete msg;
+}
+
+typedef enum {
+    INVALID = 0,
+    STRING = 1,
+    UINT64 = 2,
+    UINT32 = 3,
+    UUID = 4,
+    UINT8 = 5,
+    UINT16 = 6,
+    DOUBLE = 7,
+    MAXVAL 
+} DbTestVarType;
+
+struct DbTestVar {
+    DbTestVar() : type(INVALID) {}
+    DbTestVar(const std::string &s) : type(STRING), str(s) {}
+    DbTestVar(uint64_t u64) : type(UINT64), u64(u64) {}
+    DbTestVar(uint32_t u32) : type(UINT32), u32(u32) {}
+    DbTestVar(const boost::uuids::uuid &uuid) : type(UUID), uuid(uuid) {}
+    DbTestVar(uint8_t u8) : type(UINT8), u8(u8) {}
+    DbTestVar(uint16_t u16) : type(UINT16), u16(u16) {}
+    DbTestVar(double d) : type(DOUBLE), d(d) {}
+
+    DbTestVarType type;
+    std::string str;
+    uint64_t u64;
+    uint32_t u32;
+    boost::uuids::uuid uuid;
+    uint8_t u8;
+    uint16_t u16;
+    double d;
+};
+
+class DbHandlerPerfTest : public ::testing::Test {
+protected:
+    static const std::string tstring_;
+    static const uint64_t tu64_;
+    static const uint32_t tu32_;
+    static const boost::uuids::uuid tuuid_;
+    static const uint8_t tu8_;
+    static const uint16_t tu16_;
+    static const double tdouble_;
+};
+
+const std::string DbHandlerPerfTest::tstring_("Test");
+const uint64_t DbHandlerPerfTest::tu64_(123456789ULL);
+const uint32_t DbHandlerPerfTest::tu32_(123456789);
+const boost::uuids::uuid DbHandlerPerfTest::tuuid_ = boost::uuids::random_generator()();
+const uint8_t DbHandlerPerfTest::tu8_(128);
+const uint16_t DbHandlerPerfTest::tu16_(65535);
+const double DbHandlerPerfTest::tdouble_(1.0);
+
+TEST_F(DbHandlerPerfTest, DISABLED_Variant) {
+    DbDataValueVec columns;
+    for (int i = 0; i < 10000; i++) {
+        columns.push_back(tstring_);
+        columns.push_back(tu64_);
+        columns.push_back(tu32_);
+        columns.push_back(tuuid_);
+        columns.push_back(tu8_);
+        columns.push_back(tu16_);
+        columns.push_back(tdouble_);
+    }
+}
+
+TEST_F(DbHandlerPerfTest, DISABLED_Struct) {
+    std::vector<DbTestVar> columns;
+    for (int i = 0; i < 10000; i++) {
+        columns.push_back(DbTestVar(tstring_));
+        columns.push_back(DbTestVar(tu64_));
+        columns.push_back(DbTestVar(tu32_));
+        columns.push_back(DbTestVar(tuuid_));
+        columns.push_back(DbTestVar(tu8_));
+        columns.push_back(DbTestVar(tu16_));
+        columns.push_back(DbTestVar(tdouble_));
+    }
 }
 
 int main(int argc, char **argv) {

--- a/src/gendb/cdb_if.cc
+++ b/src/gendb/cdb_if.cc
@@ -148,10 +148,6 @@ void CdbIf::Db_SetInitDone(bool init_done) {
 }
 
 bool CdbIf::Db_Init(std::string task_id, int task_instance) {
-    /*
-     * we can leave the queue contents as is so they can be replayed after the
-     * connection to db is established
-     */
     {
         tbb::mutex::scoped_lock lock(cdbq_mutex_);
 
@@ -163,6 +159,8 @@ bool CdbIf::Db_Init(std::string task_id, int task_instance) {
             boost::bind(&CdbIf::Db_AsyncAddColumn, this, _1)));
         cdbq_->SetStartRunnerFunc(
             boost::bind(&CdbIf::Db_IsInitDone, this));
+        cdbq_->SetExitCallback(boost::bind(&CdbIf::Db_BatchAddColumn,
+            this, _1));
 
         if (cleanup_) {
             TaskScheduler *scheduler = TaskScheduler::GetInstance();
@@ -688,107 +686,119 @@ bool CdbIf::NewDb_AddColumnfamily(const GenDb::NewCf& cf) {
  * called by the WorkQueue mechanism
  */
 bool CdbIf::Db_AsyncAddColumn(CdbIfColList &cl) {
-    bool ret_value = true;
-    uint64_t ts(UTCTimestampUsec());
     GenDb::ColList *new_colp(cl.gendb_cl);
-
-    if (new_colp) {
-        std::map<std::string, std::map<std::string, std::vector<cassandra::Mutation> > > mutation_map;
-        std::vector<cassandra::Mutation> mutations;
-        mutations.reserve(new_colp->columns_.size());
-        GenDb::NewCf::ColumnFamilyType cftype = GenDb::NewCf::COLUMN_FAMILY_INVALID;
-
-        for (GenDb::NewColVec::iterator it = new_colp->columns_.begin();
-             it != new_colp->columns_.end(); it++) {
-                cassandra::Mutation mutation;
-                cassandra::ColumnOrSuperColumn c_or_sc;
-                cassandra::Column c;
-
-                if (it->cftype_ == GenDb::NewCf::COLUMN_FAMILY_SQL) {
-                    CDBIF_CONDCHECK_LOG_RETF((it->name.size() == 1) && (it->value.size() == 1));
-                    CDBIF_CONDCHECK_LOG_RETF(cftype != GenDb::NewCf::COLUMN_FAMILY_NOSQL);
-                    cftype = GenDb::NewCf::COLUMN_FAMILY_SQL;
-                    
-                    std::string col_name;
-                    try {
-                        col_name = boost::get<std::string>(it->name.at(0));
-                    } catch (boost::bad_get& ex) {
-                        CDBIF_HANDLE_EXCEPTION(__func__ << "Exception for boost::get, what=" << ex.what());
-                    }
-                    c.__set_name(col_name);
-                    std::string col_value;
-                    DbDataValueToStringNonComposite(col_value, it->value.at(0));
-                    c.__set_value(col_value);
-                    c.__set_timestamp(ts);
-                    if (it->ttl == -1) {
-                        if (cassandra_ttl_)
-                            c.__set_ttl(cassandra_ttl_);
-                    } else if (it->ttl) {
-                        c.__set_ttl(it->ttl);
-                    }
-
-                    c_or_sc.__set_column(c);
-                    mutation.__set_column_or_supercolumn(c_or_sc);
-                    mutations.push_back(mutation);
-                } else if (it->cftype_ == GenDb::NewCf::COLUMN_FAMILY_NOSQL) {
-                    CDBIF_CONDCHECK_LOG_RETF(cftype != GenDb::NewCf::COLUMN_FAMILY_SQL);
-                    cftype = GenDb::NewCf::COLUMN_FAMILY_NOSQL;
-
-                    std::string col_name;
-                    DbDataValueVecToString(col_name, it->name.size() != 1,
-                                           it->name);
-                    c.__set_name(col_name);
-
-                    std::string col_value;
-                    DbDataValueVecToString(col_value, it->value.size() != 1,
-                                           it->value);
-                    c.__set_value(col_value);
-
-                    c.__set_timestamp(ts);
-                    if (it->ttl == -1) {
-                        if (cassandra_ttl_)
-                            c.__set_ttl(cassandra_ttl_);
-                    } else if (it->ttl) {
-                        c.__set_ttl(it->ttl);
-                    }
-
-                    c_or_sc.__set_column(c);
-                    mutation.__set_column_or_supercolumn(c_or_sc);
-                    mutations.push_back(mutation);
-                } else {
-                    CDBIF_CONDCHECK_LOG_RETF(0);
-                }
-        }
-        std::map<std::string, std::vector<cassandra::Mutation> > cf_map;
-        cf_map.insert(std::make_pair(new_colp->cfname_, mutations));
-        std::string key_value;
-        DbDataValueVecToString(key_value, new_colp->rowkey_.size() != 1, new_colp->rowkey_);
-        mutation_map.insert(std::make_pair(key_value, cf_map));
-        try {
-            client_->batch_mutate(mutation_map, org::apache::cassandra::ConsistencyLevel::ONE);
-        } catch (InvalidRequestException& ire) {
-            CDBIF_HANDLE_EXCEPTION(__func__ << ": InvalidRequestException: " << ire.why << "for cf: " << new_colp->cfname_);
-        } catch (UnavailableException& ue) {
-            CDBIF_HANDLE_EXCEPTION(__func__ << "UnavailableException: " << ue.what() << "for cf: " << new_colp->cfname_);
-        } catch (TimedOutException& te) {
-            CDBIF_HANDLE_EXCEPTION(__func__ << "TimedOutException: " << te.what() << "for cf: " << new_colp->cfname_);
-        } catch (TTransportException& te) {
-            CDBIF_HANDLE_EXCEPTION(__func__ << ": TTransportException what: " << te.what());
-            errhandler_();
-            ret_value = false;
-        } catch (TException& tx) {
-            CDBIF_HANDLE_EXCEPTION(__func__ << ": TTransportException what: " << tx.what() << new_colp->cfname_);
-        }
-    } else {
+    if (new_colp == NULL) {
         CDBIF_HANDLE_EXCEPTION(__func__ << ": No column info passed");
+        return true;
     }
+    uint64_t ts(UTCTimestampUsec());
+    std::string cfname(new_colp->cfname_);
+    // Does the row key exist in the Cassandra mutation map ?
+    std::string key_value;
+    DbDataValueVecToString(key_value, new_colp->rowkey_.size() != 1,
+                           new_colp->rowkey_);
+    CassandraMutationMap::iterator cmm_it = mutation_map_.find(key_value);
+    if (cmm_it == mutation_map_.end()) {
+        cmm_it = mutation_map_.insert(
+            std::pair<std::string, CFMutationMap>(key_value,
+                CFMutationMap())).first;
+    } 
+    CFMutationMap &cf_mutation_map(cmm_it->second);
+    // Does the column family exist in the column family mutation map ?
+    CFMutationMap::iterator cfmm_it = cf_mutation_map.find(cfname);
+    if (cfmm_it == cf_mutation_map.end()) {
+        cfmm_it = cf_mutation_map.insert(
+            std::pair<std::string, MutationList>(cfname, MutationList())).first;
+    }
+    MutationList &mutations(cfmm_it->second);
+    mutations.reserve(mutations.size() + new_colp->columns_.size());
 
-    /* allocated when enqueued, free it after processing */
-    if (new_colp) {
-        delete new_colp;
-        cl.gendb_cl = NULL;
+    GenDb::NewCf::ColumnFamilyType cftype = GenDb::NewCf::COLUMN_FAMILY_INVALID;
+    for (GenDb::NewColVec::iterator it = new_colp->columns_.begin();
+         it != new_colp->columns_.end(); it++) {
+        cassandra::Mutation mutation;
+        cassandra::ColumnOrSuperColumn c_or_sc;
+        cassandra::Column c;
+
+        if (it->cftype_ == GenDb::NewCf::COLUMN_FAMILY_SQL) {
+            CDBIF_CONDCHECK_LOG_RETF((it->name->size() == 1) && 
+                                     (it->value->size() == 1));
+            CDBIF_CONDCHECK_LOG_RETF(cftype != GenDb::NewCf::COLUMN_FAMILY_NOSQL);
+            cftype = GenDb::NewCf::COLUMN_FAMILY_SQL;
+            // Column Name
+            std::string col_name;
+            try {
+                col_name = boost::get<std::string>(it->name->at(0));
+            } catch (boost::bad_get& ex) {
+                CDBIF_HANDLE_EXCEPTION(__func__ << "Exception for boost::get, what=" << ex.what());
+            }
+            c.__set_name(col_name);
+            // Column Value
+            std::string col_value;
+            DbDataValueToStringNonComposite(col_value, it->value->at(0));
+            c.__set_value(col_value);
+            // Timestamp and TTL
+            c.__set_timestamp(ts);
+            if (it->ttl == -1) {
+                if (cassandra_ttl_) {
+                    c.__set_ttl(cassandra_ttl_);
+                }
+            } else if (it->ttl) {
+                c.__set_ttl(it->ttl);
+            }
+            c_or_sc.__set_column(c);
+            mutation.__set_column_or_supercolumn(c_or_sc);
+            mutations.push_back(mutation);
+        } else if (it->cftype_ == GenDb::NewCf::COLUMN_FAMILY_NOSQL) {
+            CDBIF_CONDCHECK_LOG_RETF(cftype != GenDb::NewCf::COLUMN_FAMILY_SQL);
+            cftype = GenDb::NewCf::COLUMN_FAMILY_NOSQL;
+            // Column Name
+            std::string col_name;
+            DbDataValueVecToString(col_name, it->name->size() != 1, *it->name);
+            c.__set_name(col_name);
+            // Column Value
+            std::string col_value;
+            DbDataValueVecToString(col_value, it->value->size() != 1,
+                                   *it->value);
+            c.__set_value(col_value);
+            // Timestamp and TTL
+            c.__set_timestamp(ts);
+            if (it->ttl == -1) {
+                if (cassandra_ttl_) {
+                    c.__set_ttl(cassandra_ttl_);
+                }
+            } else if (it->ttl) {
+                c.__set_ttl(it->ttl);
+            }
+            c_or_sc.__set_column(c);
+            mutation.__set_column_or_supercolumn(c_or_sc);
+            mutations.push_back(mutation);
+        } else {
+            CDBIF_CONDCHECK_LOG_RETF(0);
+        }
     }
-    return ret_value;
+    // Allocated when enqueued, free it after processing
+    delete new_colp;
+    cl.gendb_cl = NULL;
+    return true;
+}
+
+void CdbIf::Db_BatchAddColumn(bool done) {
+    try {
+        client_->batch_mutate(mutation_map_, org::apache::cassandra::ConsistencyLevel::ONE);
+    } catch (InvalidRequestException& ire) {
+        CDBIF_HANDLE_EXCEPTION(__func__ << ": InvalidRequestException: " << ire.why);
+    } catch (UnavailableException& ue) {
+        CDBIF_HANDLE_EXCEPTION(__func__ << "UnavailableException: " << ue.what());
+    } catch (TimedOutException& te) {
+        CDBIF_HANDLE_EXCEPTION(__func__ << "TimedOutException: " << te.what());
+    } catch (TTransportException& te) {
+        CDBIF_HANDLE_EXCEPTION(__func__ << ": TTransportException what: " << te.what());
+        errhandler_();
+    } catch (TException& tx) {
+        CDBIF_HANDLE_EXCEPTION(__func__ << ": TException what: " << tx.what());
+    }
+    mutation_map_.clear();
 }
 
 bool CdbIf::NewDb_AddColumn(std::auto_ptr<GenDb::ColList> cl) {
@@ -802,7 +812,12 @@ bool CdbIf::NewDb_AddColumn(std::auto_ptr<GenDb::ColList> cl) {
 bool CdbIf::AddColumnSync(std::auto_ptr<GenDb::ColList> cl) {
     CdbIfColList qentry;
     qentry.gendb_cl = cl.release();
-    return (Db_AsyncAddColumn(qentry));
+    bool success = Db_AsyncAddColumn(qentry);
+    if (!success) {
+        return success;
+    }
+    Db_BatchAddColumn(true);
+    return true;
 }
 
 bool CdbIf::ColListFromColumnOrSuper(GenDb::ColList& ret,
@@ -824,25 +839,25 @@ bool CdbIf::ColListFromColumnOrSuper(GenDb::ColList& ret,
                 CDBIF_CONDCHECK_LOG(0);
                 continue;
             }
-            GenDb::NewCol col(citer->column.name, res);
+            GenDb::NewCol *col(new GenDb::NewCol(citer->column.name, res));
             columns.push_back(col);
         }
     } else if (cf->cftype_ == NewCf::COLUMN_FAMILY_NOSQL) {
         NewColVec& columns = ret.columns_;
         std::vector<cassandra::ColumnOrSuperColumn>::iterator citer;
         for (citer = result.begin(); citer != result.end(); citer++) {
-            GenDb::DbDataValueVec name;
-            if (!CdbIf::DbDataValueVecFromString(name, cf->comparator_type, citer->column.name)) {
+            GenDb::DbDataValueVec *name(new GenDb::DbDataValueVec);
+            if (!CdbIf::DbDataValueVecFromString(*name, cf->comparator_type, citer->column.name)) {
                 CDBIF_CONDCHECK_LOG(0);
                 continue;
             }
-            GenDb::DbDataValueVec value;
-            if (!CdbIf::DbDataValueVecFromString(value, cf->default_validation_class, citer->column.value)) {
+            GenDb::DbDataValueVec *value(new GenDb::DbDataValueVec);
+            if (!CdbIf::DbDataValueVecFromString(*value, cf->default_validation_class, citer->column.value)) {
                 CDBIF_CONDCHECK_LOG(0);
                 continue;
             }
 
-            GenDb::NewCol col(name, value);
+            GenDb::NewCol *col(new GenDb::NewCol(name, value));
             columns.push_back(col);
         }
     }
@@ -893,7 +908,7 @@ bool CdbIf::Db_GetRow(GenDb::ColList& ret, const std::string& cfname,
     return (CdbIf::ColListFromColumnOrSuper(ret, result, cfname));
 }
 
-bool CdbIf::Db_GetMultiRow(std::vector<GenDb::ColList>& ret,
+bool CdbIf::Db_GetMultiRow(GenDb::ColListVec& ret,
         const std::string& cfname, const std::vector<DbDataValueVec>& rowkeys,
         GenDb::ColumnNameRange *crange_ptr) {
     CdbIfCfInfo *info;
@@ -970,12 +985,12 @@ bool CdbIf::Db_GetMultiRow(std::vector<GenDb::ColList>& ret,
 
         for (std::map<std::string, std::vector<ColumnOrSuperColumn> >::iterator it = ret_c.begin();
                 it != ret_c.end(); it++) {
-            GenDb::ColList col_list;
-            if (!CdbIf::DbDataValueVecFromString(col_list.rowkey_, cf->key_validation_class, it->first)) {
+            std::auto_ptr<GenDb::ColList> col_list(new GenDb::ColList);
+            if (!CdbIf::DbDataValueVecFromString(col_list->rowkey_, cf->key_validation_class, it->first)) {
                 CDBIF_CONDCHECK_LOG(0);
                 continue;
             }
-            CdbIf::ColListFromColumnOrSuper(col_list, it->second, cfname);
+            CdbIf::ColListFromColumnOrSuper(*col_list, it->second, cfname);
             ret.push_back(col_list);
         }
 
@@ -1002,7 +1017,7 @@ bool CdbIf::Db_GetRangeSlices(GenDb::ColList& col_list,
     if (col_limit_reached && (col_list.columns_.size()>0))
     {
         // copy last entry of result returned as column start for next qry
-        crange_new.start_ = (col_list.columns_.back()).name;
+        crange_new.start_ = *(col_list.columns_.back()).name;
     }
 
     // extract rest of the result
@@ -1018,14 +1033,14 @@ bool CdbIf::Db_GetRangeSlices(GenDb::ColList& col_list,
         // copy last entry of result returned as column start for next qry
         if (col_limit_reached && (next_col_list.columns_.size()>0))
         {
-            crange_new.start_ = (next_col_list.columns_.back()).name;
+            crange_new.start_ = *(next_col_list.columns_.back()).name;
         }
 
         // copy result after the first entry
         NewColVec::iterator it = next_col_list.columns_.begin();
         if (it != next_col_list.columns_.end()) it++;
-        col_list.columns_.insert(
-                col_list.columns_.end(), it, next_col_list.columns_.end());
+        col_list.columns_.transfer(col_list.columns_.end(), it,
+            next_col_list.columns_.end(), next_col_list.columns_);
     }
 
     return result;

--- a/src/gendb/cdb_if.h
+++ b/src/gendb/cdb_if.h
@@ -84,7 +84,7 @@ class CdbIf : public GenDbIf {
 
         virtual bool Db_GetRow(GenDb::ColList& ret, const std::string& cfname,
                 const GenDb::DbDataValueVec& rowkey);
-        virtual bool Db_GetMultiRow(std::vector<GenDb::ColList>& ret,
+        virtual bool Db_GetMultiRow(GenDb::ColListVec& ret,
                 const std::string& cfname, const std::vector<GenDb::DbDataValueVec>& key,
                 GenDb::ColumnNameRange *crange_ptr = NULL);
         /* api to get range of column data for a range of rows */
@@ -177,6 +177,7 @@ class CdbIf : public GenDbIf {
         bool ColListFromColumnOrSuper(GenDb::ColList&, std::vector<org::apache::cassandra::ColumnOrSuperColumn>&, const string&);
 
         bool Db_AsyncAddColumn(CdbIfColList &cl);
+        void Db_BatchAddColumn(bool done);
         bool Db_Columnfamily_present(const std::string& cfname);
         bool Db_GetColumnfamily(CdbIfCfInfo **info, const std::string& cfname);
         bool Db_IsInitDone() const;
@@ -233,6 +234,23 @@ class CdbIf : public GenDbIf {
         CleanupTask *cleanup_;
 
         int cassandra_ttl_;
+        typedef std::vector<Mutation> MutationList;
+        typedef std::map<std::string, MutationList> CFMutationMap;
+        typedef std::map<std::string, CFMutationMap> CassandraMutationMap;
+        CassandraMutationMap mutation_map_;
+};
+
+template<>
+struct WorkQueueDelete<CdbIf::CdbIfColList> {
+    template <typename QueueT>
+    void operator()(QueueT &q) {
+        for (typename QueueT::iterator iter = q.unsafe_begin();
+             iter != q.unsafe_end(); ++iter) {
+            CdbIf::CdbIfColList &colList(*iter);
+            delete colList.gendb_cl;
+            colList.gendb_cl = NULL;
+        }
+    }
 };
 
 #endif

--- a/src/gendb/gendb_if.cc
+++ b/src/gendb/gendb_if.cc
@@ -5,10 +5,6 @@
 #include "gendb_if.h"
 #include "cdb_if.h"
 
-GenDb::NewCol::NewCol(const std::string& n, const DbDataValue& v, int ttl) :
-    cftype_(NewCf::COLUMN_FAMILY_SQL), name(1, n), value(1, v), ttl(ttl) {
-}
-
 GenDb::GenDbIf *GenDbIf::GenDbIfImpl(boost::asio::io_service *ioservice,
         DbErrorHandler hdlr, std::string cassandra_ip,
         unsigned short cassandra_port, int analytics_ttl, std::string name) {

--- a/src/query_engine/db_query.cc
+++ b/src/query_engine/db_query.cc
@@ -24,7 +24,7 @@ query_status_t DbQueryUnit::process_query()
     cr.finish_.push_back(timestamp_end);
 
     std::vector<GenDb::DbDataValueVec> keys;    // vector of keys for multi-row get
-    std::vector<GenDb::ColList> mget_res;   // vector of result for each row
+    GenDb::ColListVec mget_res;   // vector of result for each row
     for (uint32_t t2 = t2_start; t2 <= t2_end; t2++)
     {
         GenDb::ColList result;
@@ -49,7 +49,7 @@ query_status_t DbQueryUnit::process_query()
     if (!m_query->dbif->Db_GetMultiRow(mget_res, cfname, keys, &cr)) {
         QE_IO_ERROR_RETURN(0, QUERY_FAILURE);
     } else {
-        for (std::vector<GenDb::ColList>::iterator it = mget_res.begin();
+        for (GenDb::ColListVec::iterator it = mget_res.begin();
                 it != mget_res.end(); it++) {
             uint32_t t2 = boost::get<uint32_t>(it->rowkey_.at(0));
             GenDb::NewColVec::iterator i;
@@ -64,28 +64,28 @@ query_status_t DbQueryUnit::process_query()
                     uint32_t t1;
                     
                     if (m_query->is_stat_table_query()) {
-                        assert(i->name.size()==4);
-                        assert(i->value.size()==1);                        
+                        assert(i->name->size()==4);
+                        assert(i->value->size()==1);                        
                         try {
-                            t1 = boost::get<uint32_t>(i->name[2]);
+                            t1 = boost::get<uint32_t>(i->name->at(2));
                         } catch (boost::bad_get& ex) {
                             assert(0);
                         }
                     } else if (m_query->is_flow_query()) {
-                        int ts_at = i->name.size() - 2;
+                        int ts_at = i->name->size() - 2;
                         assert(ts_at >= 0);
                         
                         try {
-                            t1 = boost::get<uint32_t>(i->name.at(ts_at));
+                            t1 = boost::get<uint32_t>(i->name->at(ts_at));
                         } catch (boost::bad_get& ex) {
                             assert(0);
                         }
                     } else {
-                        int ts_at = i->name.size() - 1;
+                        int ts_at = i->name->size() - 1;
                         assert(ts_at >= 0);
                         
                         try {
-                            t1 = boost::get<uint32_t>(i->name.at(ts_at));
+                            t1 = boost::get<uint32_t>(i->name->at(ts_at));
                         } catch (boost::bad_get& ex) {
                             assert(0);
                         }
@@ -108,7 +108,7 @@ query_status_t DbQueryUnit::process_query()
                         boost::uuids::uuid uuid;
 
                         try {
-                            uuid = boost::get<boost::uuids::uuid>(i->name[3]);
+                            uuid = boost::get<boost::uuids::uuid>(i->name->at(3));
                         } catch (boost::bad_get& ex) {
                             QE_ASSERT(0);
                         } catch (const std::out_of_range& oor) {
@@ -116,7 +116,7 @@ query_status_t DbQueryUnit::process_query()
                         }
 
                         try {
-                            attribstr = boost::get<std::string>(i->value[0]);
+                            attribstr = boost::get<std::string>(i->value->at(0));
                         } catch (boost::bad_get& ex) {
                             QE_ASSERT(0);
                         } catch (const std::out_of_range& oor) {
@@ -127,7 +127,7 @@ query_status_t DbQueryUnit::process_query()
                             attribstr,
                             uuid);
                     } else {
-                        result_unit.info = i->value;
+                        result_unit.info = *i->value;
                     }
 
                     query_result.push_back(result_unit);

--- a/src/query_engine/query.cc
+++ b/src/query_engine/query.cc
@@ -977,14 +977,14 @@ QueryEngine::QueryEngine(EventManager *evm,
                         it != col_list.columns_.end(); it++) {
                     std::string col_name;
                     try {
-                        col_name = boost::get<std::string>(it->name[0]);
+                        col_name = boost::get<std::string>(it->name->at(0));
                     } catch (boost::bad_get& ex) {
                         QE_LOG_NOQID(ERROR, __func__ << ": Exception on col_name get");
                     }
 
                     if (col_name == g_viz_constants.SYSTEM_OBJECT_START_TIME) {
                         try {
-                            stime = boost::get<uint64_t>(it->value.at(0));
+                            stime = boost::get<uint64_t>(it->value->at(0));
                             init_done = true;
                         } catch (boost::bad_get& ex) {
                             QE_LOG_NOQID(ERROR, __func__ << "Exception for boost::get, what=" << ex.what());

--- a/src/query_engine/select.cc
+++ b/src/query_engine/select.cc
@@ -263,7 +263,7 @@ query_status_t SelectQuery::process_query() {
             uuid_list.insert(u);
         }
 
-        std::vector<GenDb::ColList> mget_res;
+        GenDb::ColListVec mget_res;
         if (!m_query->dbif->Db_GetMultiRow(mget_res, g_viz_constants.FLOW_TABLE, keys)) {
             QE_IO_ERROR_RETURN(0, QUERY_FAILURE);
         }
@@ -278,7 +278,7 @@ query_status_t SelectQuery::process_query() {
         const GenDb::NewCf::SqlColumnMap& sql_cols = fit->cfcolumns_;
         GenDb::NewCf::SqlColumnMap::const_iterator col_type_it;
 
-        for (std::vector<GenDb::ColList>::iterator it = mget_res.begin();
+        for (GenDb::ColListVec::iterator it = mget_res.begin();
                 it != mget_res.end(); it++) {
             boost::uuids::uuid u;
             assert(it->rowkey_.size() > 0);
@@ -299,16 +299,16 @@ query_status_t SelectQuery::process_query() {
 
             for (GenDb::NewColVec::iterator jt = it->columns_.begin();
                     jt != it->columns_.end(); jt++) {
-                QE_ASSERT(jt->name.size() == 1 &&
-                        jt->value.size() == 1);
+                QE_ASSERT(jt->name->size() == 1 &&
+                        jt->value->size() == 1);
                 std::string col_name;
                 try {
-                    col_name = boost::get<std::string>(jt->name[0]);
+                    col_name = boost::get<std::string>(jt->name->at(0));
                 } catch (boost::bad_get& ex) {
                     QE_ASSERT(0);
                 }
 
-                col_res_map.insert(std::make_pair(col_name, jt->value[0]));
+                col_res_map.insert(std::make_pair(col_name, jt->value->at(0)));
             }
             if (!col_res_map.size()) {
                 QE_LOG(ERROR, "No entry for uuid: " << UuidToString(u) <<
@@ -517,25 +517,25 @@ query_status_t SelectQuery::process_query() {
             keys.push_back(a_key);
         }
 
-        std::vector<GenDb::ColList> mget_res;
+        GenDb::ColListVec mget_res;
         if (!m_query->dbif->Db_GetMultiRow(mget_res, g_viz_constants.OBJECT_VALUE_TABLE, keys)) {
             QE_IO_ERROR_RETURN(0, QUERY_FAILURE);
         }
 
         std::set<std::string> unique_values;
 
-        std::vector<GenDb::ColList>::iterator first_it = mget_res.begin();
-        std::vector<GenDb::ColList>::iterator last_it = mget_res.begin();
+        GenDb::ColListVec::iterator first_it = mget_res.begin();
+        GenDb::ColListVec::iterator last_it = mget_res.begin();
         if (mget_res.size() > 0)
             std::advance(last_it, mget_res.size()-1);
-        for (std::vector<GenDb::ColList>::iterator it = mget_res.begin();
+        for (GenDb::ColListVec::iterator it = mget_res.begin();
                 it != mget_res.end(); it++) {
             for (GenDb::NewColVec::iterator jt = it->columns_.begin();
                     jt != it->columns_.end(); jt++) {
                 if (it == first_it) {
                     uint32_t t1;
                     try {
-                        t1 = boost::get<uint32_t>(jt->name.at(0));
+                        t1 = boost::get<uint32_t>(jt->name->at(0));
                     } catch (boost::bad_get& ex) {
                         assert(0);
                     }
@@ -545,7 +545,7 @@ query_status_t SelectQuery::process_query() {
                 if (it == last_it) {
                     uint32_t t1;
                     try {
-                        t1 = boost::get<uint32_t>(jt->name.at(0));
+                        t1 = boost::get<uint32_t>(jt->name->at(0));
                     } catch (boost::bad_get& ex) {
                         assert(0);
                     }
@@ -554,7 +554,7 @@ query_status_t SelectQuery::process_query() {
                 }
                 std::string value;
                 try {
-                    value = boost::get<std::string>(jt->value.at(0));
+                    value = boost::get<std::string>(jt->value->at(0));
                 } catch (boost::bad_get& ex) {
                     assert(0);
                 }
@@ -590,24 +590,24 @@ query_status_t SelectQuery::process_query() {
             keys.push_back(a_key);
         }
 
-        std::vector<GenDb::ColList> mget_res;
+        GenDb::ColListVec mget_res;
         if (!m_query->dbif->Db_GetMultiRow(mget_res, 
                     g_viz_constants.COLLECTOR_GLOBAL_TABLE, keys)) {
             QE_IO_ERROR_RETURN(0, QUERY_FAILURE);
         }
-        for (std::vector<GenDb::ColList>::iterator it = mget_res.begin();
+        for (GenDb::ColListVec::iterator it = mget_res.begin();
                 it != mget_res.end(); it++) {
             std::map<std::string, GenDb::DbDataValue> col_res_map;
             for (GenDb::NewColVec::iterator jt = it->columns_.begin();
                     jt != it->columns_.end(); jt++) {
                 std::string col_name;
                 try {
-                    col_name = boost::get<std::string>(jt->name[0]);
+                    col_name = boost::get<std::string>(jt->name->at(0));
                 } catch (boost::bad_get& ex) {
                     QE_ASSERT(0);
                 }
 
-                col_res_map.insert(std::make_pair(col_name, jt->value[0]));
+                col_res_map.insert(std::make_pair(col_name, jt->value->at(0)));
             }
             if (!col_res_map.size()) {
                 boost::uuids::uuid u;


### PR DESCRIPTION
1. In cdbq dequeue callback accumulate the mutations to be written
   to cassandra in mutation map and then do batch write to cassandra
   from cdbq task exit callback. This improves cdbq cassandra write
   performance since we are bunching kMaxIterations write. Cdbq can
   now handle database writes corresponding to around 2K sandesh
   messages/sec.
2. Changed GenDb::NewCol to contain pointer to DbDataValueVec to
   minimize copying
3. Changed GenDb::ColList to contain ptr_vector of NewCol instead
   to vector to minimize copying
4. Add watermarks for SandeshStateMachine work queue to prevent
   vizd running out of memory
5. Scope SandeshRole enum to prevent clash with classes Generator
   and Collector in vizd
6. Fix memory leak in CdbIfQueue in cases when Generator disconnects
   and the queue contains items, introduced via commit
   f2524f9c64ebf69116065a39794890ea3cc739f0
