### PR TITLE
obj_uuid is not initialized in case uuid is requested in post request

### DIFF
--- a/src/config/api-server/vnc_cfg_ifmap.py
+++ b/src/config/api-server/vnc_cfg_ifmap.py
@@ -1176,6 +1176,7 @@ class VncDbClient(object):
     def dbe_alloc(self, obj_type, obj_dict, uuid_requested=None):
         try:
             if uuid_requested:
+                obj_uuid = uuid_requested
                 ok = self.set_uuid(obj_type, obj_dict, uuid.UUID(uuid_requested))
             else:
                 (ok, obj_uuid) = self._alloc_set_uuid(obj_type, obj_dict)


### PR DESCRIPTION
In the catch block, obj_uuid is accessed before assignment.
