### PR TITLE
Patch in: 6c5ad2541195c9f59e8ff04a50cc8f98e7741e87

### DIFF
--- a/lib/hiredis/SConscript
+++ b/lib/hiredis/SConscript
@@ -11,7 +11,7 @@ include = [ third_party_path, hiredis_path, hiredis_path + '/adapters',
         '#/build/include', '#/third_party/tbb40_20111130oss/include' ]
 
 env.Append(CPPPATH = include)
-#env.Append(CCFLAGS = ['-g'])
+env.Append(CCFLAGS = ['-g'])
 
 env.VariantDir('#/' + Dir('.').path + '/src', hiredis_path)
 hiredis_buildpath = Dir('.').abspath + '/src'

--- a/src/analytics/redis_connection.cc
+++ b/src/analytics/redis_connection.cc
@@ -57,7 +57,7 @@ RedisAsyncConnection::~RedisAsyncConnection() {
         assert(it != fns_map.end());
         fns_map.erase(it);
       }
-      redisAsyncDisconnect(context_);
+      redisAsyncFree(context_);
     }    
     reconnect_timer_.cancel(ec);
 }


### PR DESCRIPTION
commit 6c5ad2541195c9f59e8ff04a50cc8f98e7741e87
Author: Megh Bhatt <meghb@ubuntu-build02.(none)>
Date:   Thu Mar 6 20:28:07 2014 -0800

```
1. Build hiredis with -g to aid in debugging
2. Call redisAsyncFree instead of redisAsyncDisconnect when
   destroying RedisAsyncConnection since redisAsyncDisconnect
   expects clean disconnect with redis server and this may
   not happen on master switchover
```
