### PR TITLE
Giving the collector timer task the same task-id as the trigger task, to...

### DIFF
--- a/src/analytics/main.cc
+++ b/src/analytics/main.cc
@@ -390,7 +390,8 @@ int main(int argc, char *argv[])
         new TaskTrigger(boost::bind(&CollectorInfoLogger, vsc),
                     TaskScheduler::GetInstance()->GetTaskId("vizd::Stats"), 0);
     collector_info_log_timer = TimerManager::CreateTimer(*evm.io_service(),
-                                                    "Collector Info log timer");
+        "Collector Info log timer",
+        TaskScheduler::GetInstance()->GetTaskId("vizd::Stats"), 0);
     collector_info_log_timer->Start(5*1000, boost::bind(&CollectorInfoLogTimer), NULL);
     signal(SIGTERM, terminate);
     evm.Run();


### PR DESCRIPTION
... prevent a race condition that causes generators to disappear from redis
