### PR TITLE
Issue : Some flows show abnormally high stats (Bug 2527)

### DIFF
--- a/src/vnsw/agent/pkt/flow_table.cc
+++ b/src/vnsw/agent/pkt/flow_table.cc
@@ -149,6 +149,11 @@ uint32_t FlowEntry::MatchAcl(const PacketHeader &hdr,
     return action;
 }
 
+void FlowEntry::ResetStats() {
+    stats_.bytes = 0;
+    stats_.packets = 0;
+}
+
 // Recompute FlowEntry action
 bool FlowEntry::ActionRecompute() {
     uint32_t action = 0;
@@ -997,6 +1002,7 @@ void FlowTable::DeleteInternal(FlowEntryMap::iterator &it)
 
     fe->stats_.teardown_time = UTCTimestampUsec();
     fec->FlowExport(fe, diff_bytes, diff_packets);
+    fe->ResetStats();
 
     // Unlink the reverse flow, if one exists
     FlowEntry *rflow = fe->reverse_flow_entry();

--- a/src/vnsw/agent/pkt/flow_table.h
+++ b/src/vnsw/agent/pkt/flow_table.h
@@ -283,6 +283,7 @@ class FlowEntry {
     uint32_t MatchAcl(const PacketHeader &hdr,
                       std::list<MatchAclParams> &acl, bool add_implicit_deny);
     void ResetPolicy();
+    void ResetStats();
     void set_deleted(bool deleted) { deleted_ = deleted; }
     bool deleted() { return deleted_; }
     bool FlowSrcMatch(const RouteFlowKey &rkey) const;


### PR DESCRIPTION
Fix   :
When a flow is deleted and re-added (flow-entry data-structure reuse in
agent- This happens when agent has sent delete to Kernel but is waiting
for Del-Ack. In the meantime, flow add req has come from Kernel), the
agent flow entry has old stats values. When we export stats to collector,
we increment overflow bit, if  agent flow stats is greater than Kernel
flow stats. The issue happening as part of this bug is flow was getting
deleted and re-added and overflow bit was getting set (which results in
high stats value).
The fix is to reset flow stats when the flow entry delete is
being sent to Kernel after exporting the stats to collector.

Thanks and regards,
Ashok
