### PR TITLE
Modify metadata address derivation to support more than 256 interfaces.

### DIFF
--- a/src/vnsw/agent/ksync/interface_ksync.cc
+++ b/src/vnsw/agent/ksync/interface_ksync.cc
@@ -387,7 +387,7 @@ int InterfaceKSyncEntry::ChangeMsg(char *buf, int buf_len) {
 }
 
 InterfaceKSyncObject::InterfaceKSyncObject(KSync *ksync) :
-    KSyncDBObject(kInterfaceCount), ksync_(ksync), 
+    KSyncDBObject(), ksync_(ksync), 
     physical_interface_mac_(), test_mode(false) {
 }
 

--- a/src/vnsw/agent/ksync/interface_ksync.h
+++ b/src/vnsw/agent/ksync/interface_ksync.h
@@ -81,8 +81,6 @@ private:
 
 class InterfaceKSyncObject : public KSyncDBObject {
 public:
-    static const int kInterfaceCount = 1000;        // Max interfaces
-
     InterfaceKSyncObject(KSync *parent);
     virtual ~InterfaceKSyncObject();
 

--- a/src/vnsw/agent/oper/interface.cc
+++ b/src/vnsw/agent/oper/interface.cc
@@ -144,13 +144,6 @@ DBTableBase *InterfaceTable::CreateTable(DB *db, const std::string &name) {
     return interface_table_;
 };
 
-Interface *InterfaceTable::FindInterfaceFromMetadataIp(const Ip4Address &ip) {
-    uint32_t addr = ip.to_ulong();
-    if ((addr & 0xFFFF0000) != (METADATA_IP_ADDR & 0xFFFF0000))
-        return NULL;
-    return index_table_.At(addr & 0xFF);
-}
-
 Interface *InterfaceTable::FindInterface(size_t index) {
     Interface *intf = index_table_.At(index);
     if (intf && intf->IsDeleted() != true) {
@@ -176,10 +169,17 @@ bool InterfaceTable::FindVmUuidFromMetadataIp(const Ip4Address &ip,
     return false;
 }
 
-void InterfaceTable::VmPortToMetaDataIp(uint16_t ifindex, uint32_t vrfid,
+Interface *InterfaceTable::FindInterfaceFromMetadataIp(const Ip4Address &ip) {
+    uint32_t addr = ip.to_ulong();
+    if ((addr & 0xFFFF0000) != (METADATA_IP_ADDR & 0xFFFF0000))
+        return NULL;
+    return index_table_.At(addr & 0xFFFF);
+}
+
+void InterfaceTable::VmPortToMetaDataIp(uint16_t index, uint32_t vrfid,
                                         Ip4Address *addr) {
     uint32_t ip = METADATA_IP_ADDR & 0xFFFF0000;
-    ip += ((vrfid & 0xFF) << 8) + (ifindex & 0xFF);
+    ip += (index & 0xFFFF);
     *addr = Ip4Address(ip);
 }
 


### PR DESCRIPTION
Remove unused index allocation in interface-ksync object
