### PR TITLE
Use ptr_list instead of ptr_deque for SchedulingGroup::WorkQueue.

### DIFF
--- a/src/bgp/bgp_factory.cc
+++ b/src/bgp/bgp_factory.cc
@@ -38,6 +38,9 @@ FACTORY_STATIC_REGISTER(BgpObjectFactory, RoutingInstanceMgr, RoutingInstanceMgr
 #include "bgp/bgp_peer_close.h"
 FACTORY_STATIC_REGISTER(BgpObjectFactory, PeerCloseManager, PeerCloseManager);
 
+#include "bgp/scheduling_group.h"
+FACTORY_STATIC_REGISTER(BgpObjectFactory, SchedulingGroup, SchedulingGroup);
+
 #include "bgp/state_machine.h"
 FACTORY_STATIC_REGISTER(BgpObjectFactory, StateMachine, StateMachine);
 

--- a/src/bgp/bgp_factory.h
+++ b/src/bgp/bgp_factory.h
@@ -27,9 +27,11 @@ class RibOut;
 class RibOutUpdates;
 class RoutingInstance;
 class RoutingInstanceMgr;
+class SchedulingGroup;
 class StateMachine;
 
 class BgpObjectFactory : public Factory<BgpObjectFactory> {
+    FACTORY_TYPE_N0(BgpObjectFactory, SchedulingGroup);
     FACTORY_TYPE_N1(BgpObjectFactory, BgpConfigListener, BgpConfigManager *);
     FACTORY_TYPE_N1(BgpObjectFactory, BgpConfigManager, BgpServer *);
     FACTORY_TYPE_N1(BgpObjectFactory, BgpExport, RibOut *);

--- a/src/bgp/scheduling_group.h
+++ b/src/bgp/scheduling_group.h
@@ -8,7 +8,7 @@
 #include <list>
 #include <map>
 #include <vector>
-#include <boost/ptr_container/ptr_deque.hpp>
+#include <boost/ptr_container/ptr_list.hpp>
 #include <tbb/mutex.h>
 
 #include "base/bitset.h"
@@ -102,9 +102,13 @@ public:
     void clear();
     bool empty() const;
 
+protected:
+    bool running_;
+
 private:
     friend class RibOutUpdatesTest;
     friend class BgpUpdateTest;
+    friend class SchedulingGroupManagerTest;
     friend class SGTest;
     friend void IPeerSendReady(SchedulingGroup *sg, IPeerUpdate *peer);
 
@@ -115,7 +119,7 @@ private:
     struct WorkRibOut;
     struct WorkPeer;
 
-    typedef boost::ptr_deque<WorkBase> WorkQueue;
+    typedef boost::ptr_list<WorkBase> WorkQueue;
     typedef IndexMap<IPeerUpdate *, PeerState, GroupPeerSet> PeerStateMap;
     typedef IndexMap<RibOut *, RibState> RibStateMap;
     class Worker;
@@ -124,6 +128,8 @@ private:
 
     std::auto_ptr<WorkBase> WorkDequeue();
     void WorkEnqueue(WorkBase *wentry);
+    void WorkPeerEnqueue(IPeerUpdate *peer);
+    void WorkRibOutEnqueue(RibOut *ribout, int queue_id);
 
     void UpdateRibOut(RibOut *ribout, int queue_id);
     void UpdatePeer(IPeerUpdate *peer);
@@ -151,7 +157,6 @@ private:
     // The mutex controls access to WorkQueue and related Worker state.
     tbb::mutex mutex_;
     WorkQueue work_queue_;
-    bool running_;
     Worker *worker_task_;
 
     PeerStateMap peer_state_imap_;


### PR DESCRIPTION
Using ptr_deque causes problems when splitting the WorkQueue as
iterators get invalidated. Specific problem was that tranferring
the last element of a ptr_deque to another ptr_deque caused the
end() iterator for the first ptr_deque to change, thus breaking
the traversal logic.

Add unit tests for WorkQueue split and merge.
