### PR TITLE
contrail-version output for contrail-vrouter is not properly formatted. ...

### DIFF
--- a/src/config/utils/contrail-version-deb
+++ b/src/config/utils/contrail-version-deb
@@ -24,8 +24,8 @@ then
     source $VERSIONFILE
 fi
 
-echo "Package                                Version                 Build-ID | Repo | Package Name"
-echo "-------------------------------------- ----------------------- ----------------------------------"
+echo "Package                                Version                       Build-ID | Repo | Package Name"
+echo "-------------------------------------- ----------------------------- ----------------------------------"
 for i in `cat $CONTRAILRPMS`; do
   dpkg -s $i 2> /dev/null 1> /dev/null
   ret_code=$?
@@ -40,7 +40,7 @@ for i in `cat $CONTRAILRPMS`; do
   fi
   # Only Installed packages are displayed
   if [[ -n $rr ]]; then
-      printf "%-39s%-24s%-20s\n" $i $v $rr
+      printf "%-39s%-30s%-30s\n" $i $v $rr
       unset rr
   fi
 done


### PR DESCRIPTION
...The current output is

root@a3s6:~# contrail-version
Package                                Version                 Build-ID | Repo | Package Name

---

:
:
contrail-vrouter                       1.1main.2067-3.8.0-29-generic1.1main.2067-3.8.0-29-generic
:
:

Fix the width for display of version and build-id, so that we get the following output (This is required for correctly
exporting version information for vrouter in UVE)

Package                                Version                       Build-ID | Repo | Package Name

---

:
:
contrail-vrouter                       1.1main.2067-3.8.0-29-generic 1.1main.2067-3.8.0-29-generic
:
:
