### PR TITLE
Fix for 2610

### DIFF
--- a/src/config/api-server/vnc_auth_keystone.py
+++ b/src/config/api-server/vnc_auth_keystone.py
@@ -107,7 +107,6 @@ class AuthServiceKeystone(object):
         # map keystone id to users. Needed for quantum plugin because contrail
         # plugin doesn't have access to user token and ends up sending admin
         # admin token along with user-id and role
-        self._ks_cached_user_id = None
         self._ks_users = {}
 
         # configure memcache if enabled
@@ -180,9 +179,6 @@ class AuthServiceKeystone(object):
     def user_id_to_name(self, id):
         if id in self._ks_users:
             return self._ks_users[id]
-        if id == self._ks_cached_user_id:
-            return ''
-        self._ks_cached_user_id = id
 
         # fetch from keystone
         content = self.json_request('GET', '/v2.0/users')
@@ -190,7 +186,10 @@ class AuthServiceKeystone(object):
             self._ks_users = dict((user['id'], user['name'])
                                   for user in content['users'])
 
-        # retry
-        return self.user_id_to_name(id)
+        # check it again
+        if id in self._ks_users:
+            return self._ks_users[id]
+        else:
+            return ''
     # end user_id_to_name
 # end class AuthService


### PR DESCRIPTION
_ks_cached_user_id can be initialized with different value due to blocking call in json_request. It can cause infinite recursion. Avoid global variable and recursive function
