### PR TITLE
Move event_queue_ (WorkQueue) object from VmStat to VmUveTable. This is ...

### DIFF
--- a/src/vnsw/agent/uve/vm_stat.cc
+++ b/src/vnsw/agent/uve/vm_stat.cc
@@ -39,16 +39,6 @@ VmStat::~VmStat() {
     signal_.cancel(ec);
 }
 
-bool VmStat::Process(VmStatData* vm_stat_data) {
-    if (vm_stat_data->vm_stat()->marked_delete()) {
-        delete vm_stat_data->vm_stat();
-    } else {
-        vm_stat_data->vm_stat()->ProcessData();
-    }
-    delete vm_stat_data;
-    return true;
-}
-
 void VmStat::ReadData(const boost::system::error_code &ec,
                       size_t read_bytes, DoneCb &cb) {
     if (read_bytes) {

--- a/src/vnsw/agent/uve/vm_stat.h
+++ b/src/vnsw/agent/uve/vm_stat.h
@@ -29,8 +29,8 @@ public:
 
     void Start();
     void Stop();
-    static bool Process(VmStatData *vm_stat_data);
     void HandleSigChild(const boost::system::error_code& error, int sig);
+    void ProcessData();
 private:
     bool BuildVmStatsMsg(UveVirtualMachineAgent &uve);
     void RegisterSigHandler();
@@ -50,7 +50,6 @@ private:
     void ReadPid();
     void ReadMemoryQuota();
     void GetMemoryQuota();
-    void ProcessData();
 
     Agent *agent_;
     const boost::uuids::uuid vm_uuid_;

--- a/src/vnsw/agent/uve/vm_uve_table.cc
+++ b/src/vnsw/agent/uve/vm_uve_table.cc
@@ -11,7 +11,7 @@ VmUveTable::VmUveTable(Agent *agent)
       vm_listener_id_(DBTableBase::kInvalidId) {
     event_queue_.reset(new WorkQueue<VmStatData *>
             (TaskScheduler::GetInstance()->GetTaskId("Agent::Uve"), 0,
-             boost::bind(&VmStat::Process, _1)));
+             boost::bind(&VmUveTable::Process, this, _1)));
 }
 
 VmUveTable::~VmUveTable() {
@@ -230,3 +230,14 @@ void VmUveTable::UpdateBitmap(const VmEntry* vm, uint8_t proto, uint16_t sport,
 void VmUveTable::EnqueueVmStatData(VmStatData *data) {
     event_queue_->Enqueue(data);
 }
+
+bool VmUveTable::Process(VmStatData* vm_stat_data) {
+    if (vm_stat_data->vm_stat()->marked_delete()) {
+        delete vm_stat_data->vm_stat();
+    } else {
+        vm_stat_data->vm_stat()->ProcessData();
+    }
+    delete vm_stat_data;
+    return true;
+}
+

--- a/src/vnsw/agent/uve/vm_uve_table.h
+++ b/src/vnsw/agent/uve/vm_uve_table.h
@@ -52,6 +52,7 @@ public:
                       uint16_t dport);
     virtual void DispatchVmMsg(const UveVirtualMachineAgent &uve);
     void EnqueueVmStatData(VmStatData *data);
+    bool Process(VmStatData *vm_stat_data);
 
 protected:
     UveVmMap uve_vm_map_;


### PR DESCRIPTION
...required to avoid deletion of event_queue_ when VmStat gets deleted because VmStat gets deleted as part of WorkQueue handler.
