### PR TITLE
Changing trace to stats for queue threshold exceeded

### DIFF
--- a/src/vnsw/agent/pkt/pkt_handler.cc
+++ b/src/vnsw/agent/pkt/pkt_handler.cc
@@ -179,8 +179,7 @@ enqueue:
 
     if (mod != INVALID) {
         if (!(enqueue_cb_.at(mod))(pkt_info)) {
-            PKT_TRACE(Err, "Threshold exceeded while enqueuing to module <" <<
-                      mod << ">");
+            stats_.PktQThresholdExceeded(mod);
         }
         return;
     }
@@ -451,6 +450,11 @@ void PktHandler::PktStats::PktRcvd(PktModuleName mod) {
 void PktHandler::PktStats::PktSent(PktModuleName mod) {
     if (mod < MAX_MODULES)
         sent[mod]++;
+}
+
+void PktHandler::PktStats::PktQThresholdExceeded(PktModuleName mod) {
+    if (mod < MAX_MODULES)
+        q_threshold_exceeded[mod]++;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/vnsw/agent/pkt/pkt_handler.h
+++ b/src/vnsw/agent/pkt/pkt_handler.h
@@ -153,16 +153,18 @@ public:
     struct PktStats {
         uint32_t sent[MAX_MODULES];
         uint32_t received[MAX_MODULES];
+        uint32_t q_threshold_exceeded[MAX_MODULES];
         uint32_t dropped;
         void Reset() {
             for (int i = 0; i < MAX_MODULES; ++i) {
-                sent[i] = received[i] = 0;
+                sent[i] = received[i] = q_threshold_exceeded[i] = 0;
             }
             dropped = 0;
         }
         PktStats() { Reset(); }
         void PktRcvd(PktModuleName mod);
         void PktSent(PktModuleName mod);
+        void PktQThresholdExceeded(PktModuleName mod);
     };
 
     PktHandler(Agent *, const std::string &, boost::asio::io_service &, bool);

--- a/src/vnsw/agent/services/services.sandesh
+++ b/src/vnsw/agent/services/services.sandesh
@@ -48,6 +48,11 @@ response sandesh PktStats {
     10: i32 arp_sent;
     11: i32 dns_sent;
     12: i32 icmp_sent;
+    13: i32 dhcp_q_threshold_exceeded;
+    14: i32 arp_q_threshold_exceeded;
+    15: i32 dns_q_threshold_exceeded;
+    16: i32 icmp_q_threshold_exceeded;
+    17: i32 flow_q_threshold_exceeded;
 }
 
 response sandesh DhcpStats {

--- a/src/vnsw/agent/services/services_sandesh.cc
+++ b/src/vnsw/agent/services/services_sandesh.cc
@@ -106,6 +106,11 @@ void ServicesSandesh::PktStatsSandesh(std::string ctxt, bool more) {
     resp->set_arp_sent(stats.sent[PktHandler::ARP]);
     resp->set_dns_sent(stats.sent[PktHandler::DNS]);
     resp->set_icmp_sent(stats.sent[PktHandler::ICMP]);
+    resp->set_dhcp_q_threshold_exceeded(stats.q_threshold_exceeded[PktHandler::DHCP]);
+    resp->set_arp_q_threshold_exceeded(stats.q_threshold_exceeded[PktHandler::ARP]);
+    resp->set_dns_q_threshold_exceeded(stats.q_threshold_exceeded[PktHandler::DNS]);
+    resp->set_icmp_q_threshold_exceeded(stats.q_threshold_exceeded[PktHandler::ICMP]);
+    resp->set_flow_q_threshold_exceeded(stats.q_threshold_exceeded[PktHandler::FLOW]);
     resp->set_context(ctxt);
     resp->set_more(more);
     resp->Response();


### PR DESCRIPTION
under loaded scenario once the queue threshold is exceeded, trace for
queue exceed will be logged every pkt enqueue.

Removing the trace and adding stats for queue exceed for debugging.
