### PR TITLE
Adding Initialization of sg_action_summary.

### DIFF
--- a/src/vnsw/agent/pkt/flow_table.cc
+++ b/src/vnsw/agent/pkt/flow_table.cc
@@ -218,6 +218,7 @@ bool FlowEntry::DoPolicy() {
     data_.match_p.out_sg_action = 0;
     data_.match_p.mirror_action = 0;
     data_.match_p.out_mirror_action = 0;
+    data_.match_p.sg_action_summary = 0;
 
     FlowEntry *rflow = reverse_flow_entry();
     PacketHeader hdr;

--- a/src/vnsw/agent/pkt/flow_table.h
+++ b/src/vnsw/agent/pkt/flow_table.h
@@ -185,7 +185,7 @@ struct MatchPolicy {
         m_out_sg_acl_l(), out_sg_rule_present(false), out_sg_action(0), 
         m_sg_acl_l(), sg_rule_present(false), sg_action(0),
         m_mirror_acl_l(), mirror_action(0), m_out_mirror_acl_l(),
-        out_mirror_action(0), action_info() {
+        out_mirror_action(0), sg_action_summary(0), action_info() {
     }
 
     ~MatchPolicy() {}


### PR DESCRIPTION
its un-intialized use was causing crash in agent and test cases.
