### PR TITLE
This commit has some improvements for Analytics Systemless Test

### DIFF
--- a/src/analytics/test/utils/mockcassandra/mockcassandra/mockcassandra.py
+++ b/src/analytics/test/utils/mockcassandra/mockcassandra/mockcassandra.py
@@ -39,8 +39,9 @@ def start_cassandra(cport, sport_arg=None):
 
     basefile = 'apache-cassandra-'+cassandra_version
     tarfile = cassandra_url
-    cassbase = "/tmp/cassandra." + str(cport) + "/"
+    cassbase = "/tmp/cassandra.%s.%d/" % (os.getenv('USER', 'None'), cport)
     confdir = cassbase + basefile + "/conf/"
+    output,_ = call_command_("rm -rf " + cassbase)
     output,_ = call_command_("mkdir " + cassbase)
 
     logging.info('Installing cassandra in ' + cassbase)
@@ -108,7 +109,7 @@ def stop_cassandra(cport):
     Arguments:
         cport : The Client Port for the instance of cassandra to be stopped
     '''
-    cassbase = "/tmp/cassandra." + str(cport) + "/"
+    cassbase = "/tmp/cassandra.%s.%d/" % (os.getenv('USER', 'None'), cport)
     input = open(cassbase + "pid")
     s=input.read()
     logging.info('Killing Cassandra pid %d' % int(s))

--- a/src/analytics/test/utils/mockredis/mockredis/mockredis.py
+++ b/src/analytics/test/utils/mockredis/mockredis/mockredis.py
@@ -55,7 +55,7 @@ def start_redis(port, exe=None):
 
     conftemplate = os.path.dirname(os.path.abspath(__file__)) + "/" +\
         redis_conf
-    redisbase = "/tmp/redis." + str(port) + "/"
+    redisbase = "/tmp/redis.%s.%d/" % (os.getenv('USER', 'None'), port)
     output, _ = call_command_("rm -rf " + redisbase)
     output, _ = call_command_("mkdir " + redisbase)
     output, _ = call_command_("mkdir " + redisbase + "cache")
@@ -97,12 +97,7 @@ def stop_redis(port):
     r = redis.StrictRedis(host='localhost', port=port, db=0)
     r.shutdown()
     del r
-    redisbase = "/tmp/redis." + str(port) + "/"
-    '''
-    pidfile  = redisbase + "pid"
-    pid = int(open(pidfile).read())
-    os.kill(pid, signal.SIGTERM)
-    '''
+    redisbase = "/tmp/redis.%s.%d/" % (os.getenv('USER', 'None'), port)
     output, _ = call_command_("rm -rf " + redisbase)
 
 def replace_string_(filePath, findreplace):

--- a/src/opserver/test/analytics_systest.py
+++ b/src/opserver/test/analytics_systest.py
@@ -13,6 +13,8 @@
 import sys
 builddir = sys.path[0] + '/../..'
 
+import signal
+import gevent
 from gevent import monkey
 monkey.patch_all()
 import os
@@ -535,5 +537,9 @@ class AnalyticsTest(testtools.TestCase, fixtures.TestWithFixtures):
             return True
         return False
 
+def _term_handler(*_):
+    raise IntSignal()
+
 if __name__ == '__main__':
-    unittest.main()
+    gevent.signal(signal.SIGINT,_term_handler)
+    unittest.main(catchbreak=True)

--- a/src/opserver/test/utils/analytics_fixture.py
+++ b/src/opserver/test/utils/analytics_fixture.py
@@ -68,6 +68,7 @@ class Collector(object):
     def start(self):
         assert(self._instance == None)
         self._log_file = '/tmp/vizd.messages.' + str(self.listen_port)
+        subprocess.call(['rm', '-rf', self._log_file])
         args = [self.analytics_fixture.builddir + '/analytics/vizd',
             '--DEFAULT.cassandra_server_list', '127.0.0.1:' +
             str(self.analytics_fixture.cassandra_port),
@@ -130,6 +131,7 @@ class OpServer(object):
         openv['PYTHONPATH'] = self.analytics_fixture.builddir + \
             '/sandesh/library/python'
         self._log_file = '/tmp/opserver.messages.' + str(self.listen_port)
+        subprocess.call(['rm', '-rf', self._log_file])
         args = ['python', self.analytics_fixture.builddir + \
                 '/opserver/opserver/opserver.py',
                 '--redis_server_port', str(self._redis_port),
@@ -201,6 +203,7 @@ class QueryEngine(object):
     def start(self, analytics_start_time=None):
         assert(self._instance == None)
         self._log_file = '/tmp/qed.messages.' + str(self.listen_port)
+        subprocess.call(['rm', '-rf', self._log_file])
         args = [self.analytics_fixture.builddir + '/query_engine/qedt',
                 '--REDIS.port', str(self.analytics_fixture.redis_query.port),
                 '--DEFAULT.cassandra_server_list', '127.0.0.1:' +
@@ -656,7 +659,7 @@ class AnalyticsFixture(fixtures.Fixture):
         res = vns.post_query('StatTable.UveVirtualNetworkAgent.vn_stats',
                              start_time='-10m',
                              end_time='now',
-                             select_fields=['T', 'name', 'vn_stats.other_vn', 'vn_stats.vrouter', 'vn_stats.in_tpkts'],
+                             select_fields=['T', 'name', 'UUID','vn_stats.other_vn', 'vn_stats.vrouter', 'vn_stats.in_tpkts'],
                              where_clause=gen_obj.vn_all_rows['whereclause'])
         self.logger.info(str(res))
         if len(res) == gen_obj.vn_all_rows['rows']:
@@ -1454,15 +1457,24 @@ class AnalyticsFixture(fixtures.Fixture):
     # end verify_where_query
 
     def cleanUp(self):
-        super(AnalyticsFixture, self).cleanUp()
 
-        self.opserver.stop()
-        self.query_engine.stop()
+        try:
+            self.opserver.stop()
+        except:
+            pass
+        try: 
+            self.query_engine.stop()
+        except:
+            pass
         for collector in self.collectors:
-            collector.stop()
+            try:
+                collector.stop()
+            except:
+                pass
         for redis_uve in self.redis_uves:
             redis_uve.stop()
         self.redis_query.stop()
+        super(AnalyticsFixture, self).cleanUp()
 
     @staticmethod
     def get_free_port():


### PR DESCRIPTION
- Increase stat coverage for UUID and SUM cases
- Support cleaner shutdown of tests when Ctrl-C interrupts the test
- python generator fixture should shut down the sandesh connection on cleanup
- mockredis and mockcassandra can tollerate tmp files already existing : delete tmp files before launch, and use username as part of tmp filename.
