### PR TITLE
During Flow delete, the SetFlowEntry was getting invoked twice from ksyn...

### DIFF
--- a/src/ksync/ksync_sock_user.cc
+++ b/src/ksync/ksync_sock_user.cc
@@ -118,11 +118,6 @@ void KSyncSockTypeMap::FlowNatResponse(uint32_t seq_num, vr_flow_req *req) {
     nl_update_header(&cl, encode_len);
     sock->sock_.send_to(buffer(cl.cl_buf, cl.cl_msg_len), sock->local_ep_);
     nl_free(&cl);
-
-    if (fwd_flow_idx != 0xFFFFFFFF) {
-        //Activate the reverse flow-entry in flow mmap
-        KSyncSockTypeMap::SetFlowEntry(req, true);
-    }
 }
 
 void KSyncSockTypeMap::SendNetlinkDoneMsg(int seq_num) {


### PR DESCRIPTION
...c_sock_user.cc which is not required.

Fixes failure of test_sandesh_kstate.cc in flow delete path
