### PR TITLE
use loacl vm port for l2 route

### DIFF
--- a/src/vnsw/agent/oper/vm_interface.cc
+++ b/src/vnsw/agent/oper/vm_interface.cc
@@ -1284,8 +1284,7 @@ void VmInterface::UpdateL2InterfaceRoute(bool old_l2_active, bool force_update) 
     struct ether_addr *addrp = ether_aton(vm_mac().c_str());
     const string &vrf_name = vrf_.get()->GetName();
 
-    Agent *agent = static_cast<InterfaceTable *>(get_table())->agent();
-    Layer2AgentRouteTable::AddLocalVmRoute(agent->local_vm_peer(), GetUuid(),
+    Layer2AgentRouteTable::AddLocalVmRoute(peer_.get(), GetUuid(),
                                            vn_->GetName(), vrf_name, l2_label_,
                                            vxlan_id_, *addrp, ip_addr(), 32);
 }
@@ -1300,8 +1299,7 @@ void VmInterface::DeleteL2InterfaceRoute(bool old_l2_active, VrfEntry *old_vrf) 
         vxlan_id_ = 0;
     }
     struct ether_addr *addrp = ether_aton(vm_mac_.c_str());
-    Agent *agent = static_cast<InterfaceTable *>(get_table())->agent();
-    Layer2AgentRouteTable::Delete(agent->local_vm_peer(), old_vrf->GetName(),
+    Layer2AgentRouteTable::Delete(peer_.get(), old_vrf->GetName(),
                                   *addrp);
 }
 

--- a/src/vnsw/agent/test/test_xmppcs.cc
+++ b/src/vnsw/agent/test/test_xmppcs.cc
@@ -397,7 +397,7 @@ TEST_F(AgentXmppUnitTest, Connection) {
     EXPECT_STREQ(rt->dest_vn_name().c_str(), "vn1");
     //ensure active path is local-vm
     EXPECT_TRUE(rt->GetActivePath()->peer()->GetType() 
-                == Peer::LOCAL_VM_PEER);
+                == Peer::LOCAL_VM_PORT_PEER);
 
     n++; n++; n++; n++; n++;
     n_s++; n_s++; n_s++;


### PR DESCRIPTION
Test case test_xmppcs and test_xmppcs_bcast failed and covers the fix.
