### PR TITLE
Make bgp hold-time configurable per bgp-router.

### DIFF
--- a/src/bgp/bgp_config.cc
+++ b/src/bgp/bgp_config.cc
@@ -823,7 +823,9 @@ void BgpConfigManager::DefaultConfig() {
         SandeshLevel::SYS_DEBUG, BGP_LOG_FLAG_ALL,
         protocol->router_params().autonomous_system,
         protocol->router_params().identifier,
-        protocol->router_params().address, families);
+        protocol->router_params().address,
+        protocol->router_params().hold_time,
+        families);
 }
 
 //
@@ -999,13 +1001,17 @@ void BgpConfigManager::ProcessBgpProtocol(const BgpConfigDelta &delta) {
             SandeshLevel::SYS_DEBUG, BGP_LOG_FLAG_ALL,
             protocol->router_params().autonomous_system,
             protocol->router_params().identifier,
-            protocol->router_params().address, families);
+            protocol->router_params().address,
+            protocol->router_params().hold_time,
+            families);
     } else if (protocol->bgp_router()) {
         BGP_CONFIG_LOG_PROTOCOL(Update, server_, protocol,
             SandeshLevel::SYS_DEBUG, BGP_LOG_FLAG_ALL,
             protocol->router_params().autonomous_system,
             protocol->router_params().identifier,
-            protocol->router_params().address, families);
+            protocol->router_params().address,
+            protocol->router_params().hold_time,
+            families);
     }
 }
 

--- a/src/bgp/bgp_config_parser.cc
+++ b/src/bgp/bgp_config_parser.cc
@@ -296,6 +296,11 @@ static bool ParseBgpRouter(const string &instance, const xml_node &node,
         // TODO: log warning
         return false;
     }
+    if (property->autonomous_system == 0)
+        property->autonomous_system = BgpConfigManager::kDefaultAutonomousSystem;
+    if (property->identifier.empty())
+        property->identifier = property->address;
+
     if (name) {
         identifier = name.value();
     } else if (!property->address.empty()) {

--- a/src/bgp/bgp_log.sandesh
+++ b/src/bgp/bgp_log.sandesh
@@ -173,6 +173,8 @@ trace sandesh BgpConfigProtocolCreateTrace {
     6: string identifier;
     7: "Address";
     8: string address;
+    11: "Hold Time";
+    12: i32 hold_time;
     9: "Address Families";
     10: list<string> families;
 }
@@ -186,6 +188,8 @@ systemlog sandesh BgpConfigProtocolCreateLog {
     6: string identifier;
     7: "Address";
     8: string address;
+    11: "Hold Time";
+    12: i32 hold_time;
     9: "Address Families";
     10: list<string> families;
 }
@@ -209,6 +213,8 @@ trace sandesh BgpConfigProtocolUpdateTrace {
     6: string identifier;
     7: "Address";
     8: string address;
+    11: "Hold Time";
+    12: i32 hold_time;
     9: "Address Families";
     10: list<string> families;
 }
@@ -222,6 +228,8 @@ systemlog sandesh BgpConfigProtocolUpdateLog {
     6: string identifier;
     7: "Address";
     8: string address;
+    11: "Hold Time";
+    12: i32 hold_time;
     9: "Address Families";
     10: list<string> families;
 }

--- a/src/bgp/bgp_peer.cc
+++ b/src/bgp/bgp_peer.cc
@@ -617,7 +617,7 @@ void BgpPeer::SendOpen(TcpSession *session) {
     BgpServer *server = session_mgr->server();
     BgpProto::OpenMessage openmsg;
     openmsg.as_num = server->autonomous_system();
-    openmsg.holdtime = state_machine_->hold_time();
+    openmsg.holdtime = state_machine_->GetConfiguredHoldTime();
     openmsg.identifier = local_bgp_id_;
     static const uint8_t cap_mp[4][4] = {
         { 0, BgpAf::IPv4,  0, BgpAf::Unicast },

--- a/src/bgp/bgp_peer.h
+++ b/src/bgp/bgp_peer.h
@@ -194,7 +194,9 @@ public:
     void RegisterToVpnTables(bool established);
 
 private:
+    friend class BgpConfigTest;
     friend class BgpPeerTest;
+    friend class BgpServerUnitTest;
     friend class StateMachineTest;
 
     class DeleteActor;

--- a/src/bgp/bgp_server.cc
+++ b/src/bgp/bgp_server.cc
@@ -111,6 +111,13 @@ public:
                         << params.autonomous_system);
             server_->autonomous_system_ = params.autonomous_system;
         }
+
+        if (server_->hold_time_ != params.hold_time) {
+            BGP_LOG_STR(BgpConfig, SandeshLevel::SYS_DEBUG, BGP_LOG_FLAG_SYSLOG,
+                        "Updated Hold Time from " <<
+                        server_->hold_time_ << " to " << params.hold_time);
+            server_->hold_time_ = params.hold_time;
+        }
     }
 
     void ProcessNeighborConfig(const BgpNeighborConfig *neighbor_config,

--- a/src/bgp/bgp_server.h
+++ b/src/bgp/bgp_server.h
@@ -86,6 +86,7 @@ public:
     const std::string &localname() const;
     as_t autonomous_system() const { return autonomous_system_; }
     uint32_t bgp_identifier() const { return bgp_identifier_.to_ulong(); };
+    uint16_t hold_time() const { return hold_time_; }
 
     // Status
     uint32_t num_routing_instance() const;
@@ -119,6 +120,7 @@ private:
     // base config variables
     as_t autonomous_system_;
     Ip4Address bgp_identifier_;
+    uint16_t hold_time_;
 
     DB db_;
     boost::dynamic_bitset<> peer_bmap_;

--- a/src/bgp/state_machine.h
+++ b/src/bgp/state_machine.h
@@ -72,15 +72,13 @@ class StateMachine : public sc::state_machine<StateMachine, fsm::Idle> {
 public:
     typedef boost::function<void(void)> EventCB;
 
-    static const int kOpenTime = 15;                // seconds
-    static const int kConnectInterval = 30;         // seconds
-    static const int kHoldTime = 90;                // seconds
-    static const int kOpenSentHoldTime = 240;       // seconds
-    static const int kIdleHoldTime = 5000;          // milliseconds
-    static const int kMaxIdleHoldTime = 100 * 1000; // milliseconds
-    static const int kJitter = 10;                  // percentage
-
-    static const int GetDefaultHoldTime();
+    static const int kOpenTime;
+    static const int kConnectInterval;
+    static const int kHoldTime;
+    static const int kOpenSentHoldTime;
+    static const int kIdleHoldTime;
+    static const int kMaxIdleHoldTime;
+    static const int kJitter;
 
     enum State {
         IDLE        = 0,
@@ -112,6 +110,7 @@ public:
     void CancelOpenTimer();
     bool OpenTimerRunning();
 
+    int GetConfiguredHoldTime() const;
     virtual void StartHoldTimer();
     void CancelHoldTimer();
     bool HoldTimerRunning();

--- a/src/bgp/test/bgp_config_manager_test.cc
+++ b/src/bgp/test/bgp_config_manager_test.cc
@@ -99,12 +99,148 @@ protected:
     BgpConfigParser parser_;
 };
 
-//
-// Config parsing tests
-//
-// TODO:
-// Invalid config files.
-// Instance delete order.
+TEST_F(BgpConfigManagerTest, BgpRouterIdentifierChange) {
+    string content_a = FileRead("controller/src/bgp/testdata/config_test_25a.xml");
+    EXPECT_TRUE(parser_.Parse(content_a));
+    task_util::WaitForIdle();
+
+    const BgpConfigData::BgpInstanceMap &instances =
+        config_manager_->config().instances();
+    TASK_UTIL_ASSERT_TRUE(instances.end() !=
+                          instances.find(BgpConfigManager::kMasterInstance));
+    BgpConfigData::BgpInstanceMap::const_iterator loc =
+        instances.find(BgpConfigManager::kMasterInstance);
+    const BgpInstanceConfig *instance_cfg = loc->second;
+    TASK_UTIL_ASSERT_TRUE(instance_cfg != NULL);
+    const BgpProtocolConfig *protocol_cfg = instance_cfg->protocol_config();
+    TASK_UTIL_ASSERT_TRUE(protocol_cfg != NULL);
+    TASK_UTIL_ASSERT_TRUE(protocol_cfg->bgp_router() != NULL);
+
+    // Identifier should be address since it's not specified explicitly.
+    TASK_UTIL_EXPECT_EQ("127.0.0.1", protocol_cfg->router_params().identifier);
+
+    // Identifier should change to 10.1.1.1.
+    string content_b = FileRead("controller/src/bgp/testdata/config_test_25b.xml");
+    EXPECT_TRUE(parser_.Parse(content_b));
+    TASK_UTIL_EXPECT_TRUE(protocol_cfg->bgp_router() != NULL);
+    TASK_UTIL_EXPECT_EQ("10.1.1.1", protocol_cfg->router_params().identifier);
+
+    // Identifier should change to 20.1.1.1.
+    string content_c = FileRead("controller/src/bgp/testdata/config_test_25c.xml");
+    EXPECT_TRUE(parser_.Parse(content_c));
+    TASK_UTIL_EXPECT_TRUE(protocol_cfg->bgp_router() != NULL);
+    TASK_UTIL_EXPECT_EQ("20.1.1.1", protocol_cfg->router_params().identifier);
+
+    // Identifier should go back to address since it's not specified explicitly.
+    content_a = FileRead("controller/src/bgp/testdata/config_test_25a.xml");
+    EXPECT_TRUE(parser_.Parse(content_a));
+    TASK_UTIL_EXPECT_TRUE(protocol_cfg->bgp_router() != NULL);
+    TASK_UTIL_EXPECT_EQ("127.0.0.1", protocol_cfg->router_params().identifier);
+
+    boost::replace_all(content_a, "<config>", "<delete>");
+    boost::replace_all(content_a, "</config>", "</delete>");
+    EXPECT_TRUE(parser_.Parse(content_a));
+    task_util::WaitForIdle();
+
+    TASK_UTIL_EXPECT_EQ(1, config_manager_->config().instances().size());
+    TASK_UTIL_EXPECT_EQ(0, db_graph_.vertex_count());
+}
+
+TEST_F(BgpConfigManagerTest, BgpRouterAutonomousSystemChange) {
+    string content_a = FileRead("controller/src/bgp/testdata/config_test_24a.xml");
+    EXPECT_TRUE(parser_.Parse(content_a));
+    task_util::WaitForIdle();
+
+    const BgpConfigData::BgpInstanceMap &instances =
+        config_manager_->config().instances();
+    TASK_UTIL_ASSERT_TRUE(instances.end() !=
+                          instances.find(BgpConfigManager::kMasterInstance));
+    BgpConfigData::BgpInstanceMap::const_iterator loc =
+        instances.find(BgpConfigManager::kMasterInstance);
+    const BgpInstanceConfig *instance_cfg = loc->second;
+    TASK_UTIL_ASSERT_TRUE(instance_cfg != NULL);
+    const BgpProtocolConfig *protocol_cfg = instance_cfg->protocol_config();
+    TASK_UTIL_ASSERT_TRUE(protocol_cfg != NULL);
+    TASK_UTIL_ASSERT_TRUE(protocol_cfg->bgp_router() != NULL);
+
+    // AS should be kDefaultAutonomousSystem as it's not specified.
+    TASK_UTIL_EXPECT_EQ(BgpConfigManager::kDefaultAutonomousSystem,
+        protocol_cfg->router_params().autonomous_system);
+
+    // AS time should change to 100.
+    string content_b = FileRead("controller/src/bgp/testdata/config_test_24b.xml");
+    EXPECT_TRUE(parser_.Parse(content_b));
+    TASK_UTIL_EXPECT_TRUE(protocol_cfg->bgp_router() != NULL);
+    TASK_UTIL_EXPECT_EQ(100, protocol_cfg->router_params().autonomous_system);
+
+    // AS time should change to 101.
+    string content_c = FileRead("controller/src/bgp/testdata/config_test_24c.xml");
+    EXPECT_TRUE(parser_.Parse(content_c));
+    TASK_UTIL_EXPECT_TRUE(protocol_cfg->bgp_router() != NULL);
+    TASK_UTIL_EXPECT_EQ(101, protocol_cfg->router_params().autonomous_system);
+
+    // AS should go back to kDefaultAutonomousSystem as it's not specified.
+    content_a = FileRead("controller/src/bgp/testdata/config_test_24a.xml");
+    EXPECT_TRUE(parser_.Parse(content_a));
+    TASK_UTIL_EXPECT_TRUE(protocol_cfg->bgp_router() != NULL);
+    TASK_UTIL_EXPECT_EQ(BgpConfigManager::kDefaultAutonomousSystem,
+        protocol_cfg->router_params().autonomous_system);
+
+    boost::replace_all(content_a, "<config>", "<delete>");
+    boost::replace_all(content_a, "</config>", "</delete>");
+    EXPECT_TRUE(parser_.Parse(content_a));
+    task_util::WaitForIdle();
+
+    TASK_UTIL_EXPECT_EQ(1, config_manager_->config().instances().size());
+    TASK_UTIL_EXPECT_EQ(0, db_graph_.vertex_count());
+}
+
+TEST_F(BgpConfigManagerTest, BgpRouterHoldTimeChange) {
+    string content_a = FileRead("controller/src/bgp/testdata/config_test_23a.xml");
+    EXPECT_TRUE(parser_.Parse(content_a));
+    task_util::WaitForIdle();
+
+    const BgpConfigData::BgpInstanceMap &instances =
+        config_manager_->config().instances();
+    TASK_UTIL_ASSERT_TRUE(instances.end() !=
+                          instances.find(BgpConfigManager::kMasterInstance));
+    BgpConfigData::BgpInstanceMap::const_iterator loc =
+        instances.find(BgpConfigManager::kMasterInstance);
+    const BgpInstanceConfig *instance_cfg = loc->second;
+    TASK_UTIL_ASSERT_TRUE(instance_cfg != NULL);
+    const BgpProtocolConfig *protocol_cfg = instance_cfg->protocol_config();
+    TASK_UTIL_ASSERT_TRUE(protocol_cfg != NULL);
+    TASK_UTIL_ASSERT_TRUE(protocol_cfg->bgp_router() != NULL);
+
+    // Hold time should be 0 since it's not specified explicitly.
+    TASK_UTIL_EXPECT_EQ(0, protocol_cfg->router_params().hold_time);
+
+    // Hold time should change to 9.
+    string content_b = FileRead("controller/src/bgp/testdata/config_test_23b.xml");
+    EXPECT_TRUE(parser_.Parse(content_b));
+    TASK_UTIL_EXPECT_TRUE(protocol_cfg->bgp_router() != NULL);
+    TASK_UTIL_EXPECT_EQ(9, protocol_cfg->router_params().hold_time);
+
+    // Hold time should change to 27.
+    string content_c = FileRead("controller/src/bgp/testdata/config_test_23c.xml");
+    EXPECT_TRUE(parser_.Parse(content_c));
+    TASK_UTIL_EXPECT_TRUE(protocol_cfg->bgp_router() != NULL);
+    TASK_UTIL_EXPECT_EQ(27, protocol_cfg->router_params().hold_time);
+
+    // Hold time should go back to 0 since it's not specified explicitly.
+    content_a = FileRead("controller/src/bgp/testdata/config_test_23a.xml");
+    EXPECT_TRUE(parser_.Parse(content_a));
+    TASK_UTIL_EXPECT_TRUE(protocol_cfg->bgp_router() != NULL);
+    TASK_UTIL_EXPECT_EQ(0, protocol_cfg->router_params().hold_time);
+
+    boost::replace_all(content_a, "<config>", "<delete>");
+    boost::replace_all(content_a, "</config>", "</delete>");
+    EXPECT_TRUE(parser_.Parse(content_a));
+    task_util::WaitForIdle();
+
+    TASK_UTIL_EXPECT_EQ(1, config_manager_->config().instances().size());
+    TASK_UTIL_EXPECT_EQ(0, db_graph_.vertex_count());
+}
 
 TEST_F(BgpConfigManagerTest, MasterNeighbors) {
     string content = FileRead("controller/src/bgp/testdata/config_test_1.xml");

--- a/src/bgp/test/bgp_server_test_util.h
+++ b/src/bgp/test/bgp_server_test_util.h
@@ -148,6 +148,8 @@ private:
     bool cleanup_config_;
 };
 
+typedef boost::shared_ptr<BgpServerTest> BgpServerTestPtr;
+
 class BgpPeerTest : public BgpPeer {
 public:
     BgpPeerTest(BgpServer *server, RoutingInstance *rtinst,

--- a/src/bgp/test/bgp_xmpp_evpn_test.cc
+++ b/src/bgp/test/bgp_xmpp_evpn_test.cc
@@ -24,30 +24,30 @@ using namespace std;
 // Fire state machine timers faster and reduce possible delay in this test
 //
 class StateMachineTest : public StateMachine {
-    public:
-        explicit StateMachineTest(BgpPeer *peer) : StateMachine(peer) { }
-        ~StateMachineTest() { }
+public:
+    explicit StateMachineTest(BgpPeer *peer) : StateMachine(peer) { }
+    ~StateMachineTest() { }
 
-        void StartConnectTimer(int seconds) {
-            connect_timer_->Start(10,
-                boost::bind(&StateMachine::ConnectTimerExpired, this),
-                boost::bind(&StateMachine::TimerErrorHanlder, this, _1, _2));
-        }
+    void StartConnectTimer(int seconds) {
+        connect_timer_->Start(10,
+            boost::bind(&StateMachine::ConnectTimerExpired, this),
+            boost::bind(&StateMachine::TimerErrorHanlder, this, _1, _2));
+    }
 
-        void StartOpenTimer(int seconds) {
-            open_timer_->Start(10,
-                boost::bind(&StateMachine::OpenTimerExpired, this),
-                boost::bind(&StateMachine::TimerErrorHanlder, this, _1, _2));
-        }
+    void StartOpenTimer(int seconds) {
+        open_timer_->Start(10,
+            boost::bind(&StateMachine::OpenTimerExpired, this),
+            boost::bind(&StateMachine::TimerErrorHanlder, this, _1, _2));
+    }
 
-        void StartIdleHoldTimer() {
-            if (idle_hold_time_ <= 0)
-                return;
+    void StartIdleHoldTimer() {
+        if (idle_hold_time_ <= 0)
+            return;
 
-            idle_hold_timer_->Start(10,
-                boost::bind(&StateMachine::IdleHoldTimerExpired, this),
-                boost::bind(&StateMachine::TimerErrorHanlder, this, _1, _2));
-        }
+        idle_hold_timer_->Start(10,
+            boost::bind(&StateMachine::IdleHoldTimerExpired, this),
+            boost::bind(&StateMachine::TimerErrorHanlder, this, _1, _2));
+    }
 };
 
 class BgpXmppChannelMock : public BgpXmppChannel {
@@ -164,7 +164,7 @@ protected:
 
     EventManager evm_;
     ServerThread thread_;
-    auto_ptr<BgpServerTest> bs_x_;
+    BgpServerTestPtr bs_x_;
     XmppServer *xs_x_;
     boost::scoped_ptr<test::NetworkAgentMock> agent_a_;
     boost::scoped_ptr<test::NetworkAgentMock> agent_b_;
@@ -1280,6 +1280,13 @@ protected:
         task_util::WaitForIdle();
     }
 
+    void Configure(BgpServerTestPtr server, const char *cfg_template) {
+        char config[4096];
+        snprintf(config, sizeof(config), cfg_template,
+                 server->session_manager()->GetPort());
+        server->Configure(config);
+    }
+
     void Configure(const char *cfg_template = config_template_21) {
         char config[4096];
         snprintf(config, sizeof(config), cfg_template,
@@ -1291,8 +1298,8 @@ protected:
 
     EventManager evm_;
     ServerThread thread_;
-    auto_ptr<BgpServerTest> bs_x_;
-    auto_ptr<BgpServerTest> bs_y_;
+    BgpServerTestPtr bs_x_;
+    BgpServerTestPtr bs_y_;
     XmppServer *xs_x_;
     XmppServer *xs_y_;
     boost::scoped_ptr<test::NetworkAgentMock> agent_a_;
@@ -2038,8 +2045,37 @@ TEST_F(BgpXmppEvpnTest2, XmppSessionDown) {
     agent_a_->SessionDown();
 }
 
-static const char *config_template_22 = "\
+static const char *config_template_22_x = "\
 <config>\
+    <bgp-router name=\'X\'>\
+        <identifier>192.168.0.1</identifier>\
+        <address>127.0.0.1</address>\
+        <port>%d</port>\
+    </bgp-router>\
+    <virtual-network name='blue'>\
+        <network-id>1</network-id>\
+    </virtual-network>\
+    <virtual-network name='pink'>\
+        <network-id>2</network-id>\
+    </virtual-network>\
+    <routing-instance name='blue'>\
+        <virtual-network>blue</virtual-network>\
+        <vrf-target>target:1:1</vrf-target>\
+    </routing-instance>\
+    <routing-instance name='pink'>\
+        <virtual-network>pink</virtual-network>\
+        <vrf-target>target:1:2</vrf-target>\
+    </routing-instance>\
+</config>\
+";
+
+static const char *config_template_22_y = "\
+<config>\
+    <bgp-router name=\'Y\'>\
+        <identifier>192.168.0.2</identifier>\
+        <address>127.0.0.2</address>\
+        <port>%d</port>\
+    </bgp-router>\
     <virtual-network name='blue'>\
         <network-id>1</network-id>\
     </virtual-network>\
@@ -2092,9 +2128,9 @@ static const char *config_template_23 = "\
 // routes to the 2 XMPP servers.
 //
 TEST_F(BgpXmppEvpnTest2, BgpConnectLater) {
-    // Configure the routing instances.
-    bs_x_->Configure(config_template_22);
-    bs_y_->Configure(config_template_22);
+    // Configure individual bgp-routers and routing instances but no session.
+    Configure(bs_x_, config_template_22_x);
+    Configure(bs_y_, config_template_22_y);
     task_util::WaitForIdle();
 
     // Create XMPP Agent A connected to XMPP server X.
@@ -2205,8 +2241,8 @@ TEST_F(BgpXmppEvpnTest2, CreateInstanceLater) {
     TASK_UTIL_EXPECT_EQ(0, agent_b_->EnetRouteCount("blue"));
 
     // Configure the routing instances.
-    bs_x_->Configure(config_template_22);
-    bs_y_->Configure(config_template_22);
+    Configure(bs_x_, config_template_22_x);
+    Configure(bs_y_, config_template_22_y);
     task_util::WaitForIdle();
 
     // Verify that routes showed up on the agents.

--- a/src/bgp/test/state_machine_test.cc
+++ b/src/bgp/test/state_machine_test.cc
@@ -986,9 +986,9 @@ protected:
     virtual void SetUp() {
         id_ = tr1::get<0>(GetParam()) ? lower_id_ : higher_id_;
         if (tr1::get<1>(GetParam())) {
-            holdtime_ = StateMachine::GetDefaultHoldTime() - 1;
+            holdtime_ = StateMachine::kHoldTime - 1;
         } else {
-            holdtime_ = StateMachine::GetDefaultHoldTime() + 1;
+            holdtime_ = StateMachine::kHoldTime + 1;
         }
         StateMachineActiveTest::SetUp();
     }
@@ -1012,7 +1012,7 @@ TEST_P(StateMachineActiveParamTest2, BgpHoldtimeNegotiation) {
     TaskScheduler::GetInstance()->Start();
     VerifyState(StateMachine::OPENCONFIRM);
     VerifyDirection(BgpSessionMock::PASSIVE);
-    TASK_UTIL_EXPECT_EQ(min(holdtime_, StateMachine::GetDefaultHoldTime()),
+    TASK_UTIL_EXPECT_EQ(min(holdtime_, StateMachine::kHoldTime),
         sm_->hold_time());
 }
 
@@ -1362,9 +1362,9 @@ protected:
     virtual void SetUp() {
         id_ = tr1::get<0>(GetParam()) ? lower_id_ : higher_id_;
         if (tr1::get<1>(GetParam())) {
-            holdtime_ = StateMachine::GetDefaultHoldTime() - 1;
+            holdtime_ = StateMachine::kHoldTime - 1;
         } else {
-            holdtime_ = StateMachine::GetDefaultHoldTime() + 1;
+            holdtime_ = StateMachine::kHoldTime + 1;
         }
         StateMachineConnectTest::SetUp();
     }
@@ -1388,7 +1388,7 @@ TEST_P(StateMachineConnectParamTest2, BgpHoldtimeNegotiation) {
     TaskScheduler::GetInstance()->Start();
     VerifyState(StateMachine::OPENCONFIRM);
     VerifyDirection(BgpSessionMock::PASSIVE);
-    TASK_UTIL_EXPECT_EQ(min(holdtime_, StateMachine::GetDefaultHoldTime()),
+    TASK_UTIL_EXPECT_EQ(min(holdtime_, StateMachine::kHoldTime),
         sm_->hold_time());
 }
 
@@ -2212,9 +2212,9 @@ class StateMachineOpenSentParamTest2 :
 protected:
     virtual void SetUp() {
         if (GetParam()) {
-            holdtime_ = StateMachine::GetDefaultHoldTime() - 1;
+            holdtime_ = StateMachine::kHoldTime - 1;
         } else {
-            holdtime_ = StateMachine::GetDefaultHoldTime() + 1;
+            holdtime_ = StateMachine::kHoldTime + 1;
         }
         StateMachineOpenSentTest::SetUp();
     }
@@ -2234,7 +2234,7 @@ TEST_P(StateMachineOpenSentParamTest2, BgpHoldtimeNegotiation1) {
     EvOpenTimerExpiredPassive();
     EvBgpOpenCustom(session_mgr_->active_session(), lower_id_, holdtime_);
     VerifyState(StateMachine::OPENCONFIRM);
-    TASK_UTIL_EXPECT_EQ(min(holdtime_, StateMachine::GetDefaultHoldTime()),
+    TASK_UTIL_EXPECT_EQ(min(holdtime_, StateMachine::kHoldTime),
         sm_->hold_time());
 }
 
@@ -2246,7 +2246,7 @@ TEST_P(StateMachineOpenSentParamTest2, BgpHoldtimeNegotiation2) {
     EvOpenTimerExpiredPassive();
     EvBgpOpenCustom(session_mgr_->passive_session(), higher_id_, holdtime_);
     VerifyState(StateMachine::OPENCONFIRM);
-    TASK_UTIL_EXPECT_EQ(min(holdtime_, StateMachine::GetDefaultHoldTime()),
+    TASK_UTIL_EXPECT_EQ(min(holdtime_, StateMachine::kHoldTime),
         sm_->hold_time());
 }
 
@@ -2263,9 +2263,9 @@ protected:
     virtual void SetUp() {
         id_ = tr1::get<0>(GetParam()) ? lower_id_ : higher_id_;
         if (tr1::get<1>(GetParam())) {
-            holdtime_ = StateMachine::GetDefaultHoldTime() - 1;
+            holdtime_ = StateMachine::kHoldTime - 1;
         } else {
-            holdtime_ = StateMachine::GetDefaultHoldTime() + 1;
+            holdtime_ = StateMachine::kHoldTime + 1;
         }
         StateMachineOpenSentTest::SetUp();
     }
@@ -2286,7 +2286,7 @@ TEST_P(StateMachineOpenSentParamTest3, BgpHoldtimeNegotiation1) {
     EvBgpOpenCustom(session_mgr_->active_session(), id_, holdtime_);
     VerifyState(StateMachine::OPENCONFIRM);
     VerifyDirection(BgpSessionMock::ACTIVE);
-    TASK_UTIL_EXPECT_EQ(min(holdtime_, StateMachine::GetDefaultHoldTime()),
+    TASK_UTIL_EXPECT_EQ(min(holdtime_, StateMachine::kHoldTime),
         sm_->hold_time());
 }
 
@@ -2300,7 +2300,7 @@ TEST_P(StateMachineOpenSentParamTest3, BgpHoldtimeNegotiation2) {
     EvBgpOpenCustom(session_mgr_->passive_session(), id_, holdtime_);
     VerifyState(StateMachine::OPENCONFIRM);
     VerifyDirection(BgpSessionMock::PASSIVE);
-    TASK_UTIL_EXPECT_EQ(min(holdtime_, StateMachine::GetDefaultHoldTime()),
+    TASK_UTIL_EXPECT_EQ(min(holdtime_, StateMachine::kHoldTime),
         sm_->hold_time());
 }
 

--- a/src/bgp/testdata/config_test_23a.xml
+++ b/src/bgp/testdata/config_test_23a.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <routing-instance name='default-domain:default-project:ip-fabric:__default__'>
+      <bgp-router name='local'>
+          <address>127.0.0.1</address>
+          <autonomous-system>1</autonomous-system>
+      </bgp-router>
+      <bgp-router name='remote'>
+          <address>127.0.0.100</address>
+          <autonomous-system>1</autonomous-system>
+      </bgp-router>
+    </routing-instance>
+</config>

--- a/src/bgp/testdata/config_test_23b.xml
+++ b/src/bgp/testdata/config_test_23b.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <routing-instance name='default-domain:default-project:ip-fabric:__default__'>
+      <bgp-router name='local'>
+          <address>127.0.0.1</address>
+          <autonomous-system>1</autonomous-system>
+          <hold-time>9</hold-time>
+      </bgp-router>
+      <bgp-router name='remote'>
+          <address>127.0.0.100</address>
+          <autonomous-system>1</autonomous-system>
+      </bgp-router>
+    </routing-instance>
+</config>

--- a/src/bgp/testdata/config_test_23c.xml
+++ b/src/bgp/testdata/config_test_23c.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <routing-instance name='default-domain:default-project:ip-fabric:__default__'>
+      <bgp-router name='local'>
+          <address>127.0.0.1</address>
+          <autonomous-system>1</autonomous-system>
+          <hold-time>27</hold-time>
+      </bgp-router>
+      <bgp-router name='remote'>
+          <address>127.0.0.100</address>
+          <autonomous-system>1</autonomous-system>
+      </bgp-router>
+    </routing-instance>
+</config>

--- a/src/bgp/testdata/config_test_24a.xml
+++ b/src/bgp/testdata/config_test_24a.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <routing-instance name='default-domain:default-project:ip-fabric:__default__'>
+      <bgp-router name='local'>
+          <address>127.0.0.1</address>
+      </bgp-router>
+      <bgp-router name='remote'>
+          <address>127.0.0.100</address>
+          <autonomous-system>1</autonomous-system>
+      </bgp-router>
+    </routing-instance>
+</config>

--- a/src/bgp/testdata/config_test_24b.xml
+++ b/src/bgp/testdata/config_test_24b.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <routing-instance name='default-domain:default-project:ip-fabric:__default__'>
+      <bgp-router name='local'>
+          <address>127.0.0.1</address>
+          <autonomous-system>100</autonomous-system>
+      </bgp-router>
+      <bgp-router name='remote'>
+          <address>127.0.0.100</address>
+          <autonomous-system>1</autonomous-system>
+      </bgp-router>
+    </routing-instance>
+</config>

--- a/src/bgp/testdata/config_test_24c.xml
+++ b/src/bgp/testdata/config_test_24c.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <routing-instance name='default-domain:default-project:ip-fabric:__default__'>
+      <bgp-router name='local'>
+          <address>127.0.0.1</address>
+          <autonomous-system>101</autonomous-system>
+      </bgp-router>
+      <bgp-router name='remote'>
+          <address>127.0.0.100</address>
+          <autonomous-system>1</autonomous-system>
+      </bgp-router>
+    </routing-instance>
+</config>

--- a/src/bgp/testdata/config_test_25a.xml
+++ b/src/bgp/testdata/config_test_25a.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <routing-instance name='default-domain:default-project:ip-fabric:__default__'>
+      <bgp-router name='local'>
+          <address>127.0.0.1</address>
+      </bgp-router>
+      <bgp-router name='remote'>
+          <address>127.0.0.100</address>
+      </bgp-router>
+    </routing-instance>
+</config>

--- a/src/bgp/testdata/config_test_25b.xml
+++ b/src/bgp/testdata/config_test_25b.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <routing-instance name='default-domain:default-project:ip-fabric:__default__'>
+      <bgp-router name='local'>
+          <address>127.0.0.1</address>
+          <identifier>10.1.1.1</identifier>
+      </bgp-router>
+      <bgp-router name='remote'>
+          <address>127.0.0.100</address>
+      </bgp-router>
+    </routing-instance>
+</config>

--- a/src/bgp/testdata/config_test_25c.xml
+++ b/src/bgp/testdata/config_test_25c.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <routing-instance name='default-domain:default-project:ip-fabric:__default__'>
+      <bgp-router name='local'>
+          <address>127.0.0.1</address>
+          <identifier>20.1.1.1</identifier>
+      </bgp-router>
+      <bgp-router name='remote'>
+          <address>127.0.0.100</address>
+      </bgp-router>
+    </routing-instance>
+</config>

--- a/src/schema/bgp_schema.xsd
+++ b/src/schema/bgp_schema.xsd
@@ -33,15 +33,23 @@
 <!-- #IFMAP-SEMANTICS-IDL
      Property('bgp-router-parameters', 'bgp-router') -->
 
+<xsd:simpleType name='BgpHoldTime'>
+     <xsd:restriction base='xsd:integer'>
+         <xsd:minInclusive value='1'/>
+         <xsd:maxInclusive value='65535'/>
+     </xsd:restriction>
+</xsd:simpleType> 
+
 <xsd:complexType name='BgpRouterParams'>
     <xsd:sequence>
-	<xsd:element name='vendor' type='xsd:string'/>
-	<xsd:element name='vnc-managed' type='xsd:boolean'/>
-	<xsd:element name='autonomous-system' type='xsd:integer'/>
+        <xsd:element name='vendor' type='xsd:string'/>
+        <xsd:element name='vnc-managed' type='xsd:boolean'/>
+        <xsd:element name='autonomous-system' type='xsd:integer'/>
         <xsd:element name='identifier' type='smi:IpAddress'/>
         <xsd:element name='address' type='smi:IpAddress'/>
-	<xsd:element name='port' type='xsd:integer'/>
-	<xsd:element name='address-families' type='AddressFamilies'/>
+        <xsd:element name='port' type='xsd:integer'/>
+        <xsd:element name='hold-time' type='BgpHoldTime' default='90'/>
+        <xsd:element name='address-families' type='AddressFamilies'/>
     </xsd:sequence>
 </xsd:complexType>
 


### PR DESCRIPTION
Note that the code already implements hold time negotiation.

Add hold time tests to bgp_config_test.cc.
Add hold time tests to bgp_config_manager_test.cc.
Add hold time test to bgp_server_test.cc.
While we at it, also add tests for AS and RouterId change to
bgp_config_test.cc. and bgp_config_manager_test.cc.

Most changes to state machine and related tests are side-effects of
renaming GetDefaultHoldTime to GetConfiguredHoldTime and making it
non-static.
