### PR TITLE
Fix for 2648

### DIFF
--- a/src/config/api-server/vnc_addr_mgmt.py
+++ b/src/config/api-server/vnc_addr_mgmt.py
@@ -258,11 +258,10 @@ class AddrMgmt(object):
         self._create_subnet_objs(vn_fq_name_str, vn_dict)
     # end net_create_notify
 
-    def net_update_req(self, db_vn_dict, req_vn_dict, obj_uuid=None):
+    def net_update_req(self, vn_fq_name, db_vn_dict, req_vn_dict, obj_uuid=None):
         # ideally 3 way sync/audit needed here. DB to what we is in subnet_objs
         # DB to what is in request. To simplify blow away subnet_objs and do
         # sync only from DB to request.
-        vn_fq_name = db_vn_dict['fq_name']
         vn_fq_name_str = ':'.join(vn_fq_name)
 
         try:
@@ -280,7 +279,7 @@ class AddrMgmt(object):
         add_subnet_names = req_subnet_names - db_subnet_names
 
         for subnet_name in del_subnet_names:
-            Subnet.delete_cls(subnet_name)
+            Subnet.delete_cls('%s:%s' % (vn_fq_name_str, subnet_name))
 
         self._create_subnet_objs(vn_fq_name_str, req_vn_dict)
     # end net_update_req
@@ -312,10 +311,11 @@ class AddrMgmt(object):
     # purge all subnets associated with a virtual network
     def net_delete_req(self, obj_dict):
         vn_fq_name = obj_dict['fq_name']
+        vn_fq_name_str = ':'.join(vn_fq_name)
         subnet_dicts = self._get_subnet_dicts(vn_fq_name)
 
         for subnet_name in subnet_dicts:
-            Subnet.delete_cls(subnet_name)
+            Subnet.delete_cls('%s:%s' % (vn_fq_name_str, subnet_name))
 
         try:
             vn_fq_name_str = ':'.join(vn_fq_name)

--- a/src/config/common/zkclient.py
+++ b/src/config/common/zkclient.py
@@ -202,7 +202,7 @@ class ZookeeperClient(object):
         except (kazoo.exceptions.SessionExpiredError,
                 kazoo.exceptions.ConnectionLoss):
             self.reconnect()
-            self.delete_node(path)
+            self.delete_node(path, recursive=recursive)
         except kazoo.exceptions.NoNodeError:
             pass
     # end delete_node


### PR DESCRIPTION
1. If validate perms (validating the parent obj etc) fails, the action done by http_post_collection is not undone. In the case of instance-ip/floating ip, we may endup leaking a route.
2. Subnet allocator zookeeper is not deleted on delete of subnet or on update of virtual network
3. Retry of delete node doesn’t pass recursive flag
4. Confusing stevedore error due to parameter mismatch

Fix:
1. Move all validation before starting to make state changes. (http_post, http_put)
    2. For all state modification, append a cleanup routine and walk the clean up routine in failure path
    3. Added “Failure/Cleanup” hook for all required classes.
    4.  Fix the parameter list for stevedore extension method
    5. Fix subnet delete to pass correct subnet name(which should include virtual network fq name)

Sanity report: http://10.204.216.50/Docs/logs/0000_2014_03_25_17_23_01/test_report.html
