### PR TITLE
Use consistent format for families in BgpPeerInfoData.

### DIFF
--- a/src/bgp/bgp_peer.sandesh
+++ b/src/bgp/bgp_peer.sandesh
@@ -323,6 +323,7 @@ struct BgpPeerInfoData {
    13: optional string send_state;       // in sync/not in sync
    21: optional list<string> configured_families;
    14: optional list<string> families;
+   22: optional list<string> negotiated_families;
    15: optional peer_info.PeerFlapInfo flap_info;
    16: optional peer_info.PeerStateInfo state_info;
    17: optional peer_info.PeerEventInfo event_info;

--- a/src/net/bgp_af.cc
+++ b/src/net/bgp_af.cc
@@ -6,7 +6,7 @@
 
 #include <sstream>
 
-std::string BgpAf::ToString(uint8_t afi, uint16_t safi) {
+std::string BgpAf::ToString(uint16_t afi, uint8_t safi) {
     std::ostringstream out;
     switch (afi) {
         case IPv4:
@@ -19,7 +19,7 @@ std::string BgpAf::ToString(uint8_t afi, uint16_t safi) {
             out << "L2Vpn:";
             break;
         default:
-            out << "unknown:";
+            out << "Afi=" << afi << ":";
             break;
     }
     switch (safi) {
@@ -42,13 +42,13 @@ std::string BgpAf::ToString(uint8_t afi, uint16_t safi) {
             out << "RTarget";
             break;
         default:
-            out << "unknown";
+            out << "Safi=" << int(safi);
             break;
     }
     return out.str();
 }
 
-Address::Family BgpAf::AfiSafiToFamily(uint8_t afi, uint8_t safi) {
+Address::Family BgpAf::AfiSafiToFamily(uint16_t afi, uint8_t safi) {
     if (afi == BgpAf::IPv4 && safi == BgpAf::Unicast)
         return Address::INET;
     if (afi == BgpAf::IPv4 && safi == BgpAf::Vpn)

--- a/src/net/bgp_af.h
+++ b/src/net/bgp_af.h
@@ -27,8 +27,8 @@ public:
         Enet = 242,
     };
 
-    static std::string ToString(uint8_t afi, uint16_t safi);
-    static Address::Family AfiSafiToFamily(uint8_t afi, uint8_t safi);
+    static std::string ToString(uint16_t afi, uint8_t safi);
+    static Address::Family AfiSafiToFamily(uint16_t afi, uint8_t safi);
     static void FamilyToAfiSafi(Address::Family fmly, uint16_t &afi, 
                                 uint8_t &safi);
 };


### PR DESCRIPTION
Add negotiated_families field to BgpPeerInfoData.
Use same format as the configuration e.g. inet-vpn for
configured_families, families and negotiated_families.
Fix types for Afi and Safi.
