### PR TITLE
Fix for 2397

### DIFF
--- a/src/bgp/bgp_condition_listener.cc
+++ b/src/bgp/bgp_condition_listener.cc
@@ -246,6 +246,7 @@ void BgpConditionListener::SetMatchState(BgpTable *table, BgpRoute *route,
         assert(it == dbstate->list_.end());
     }
     dbstate->list_.insert(std::make_pair(obj, state));
+    obj->IncrementNumMatchstate();
 }
 
 //
@@ -266,6 +267,7 @@ void BgpConditionListener::RemoveMatchState(BgpTable *table, BgpRoute *route,
         dbstate->list_.find(ConditionMatchPtr(obj));
     assert(it != dbstate->list_.end());
     dbstate->list_.erase(it);
+    obj->DecrementNumMatchstate();
     if (dbstate->list_.empty()) {
         // Remove the DBState when last module removes the MatchState
         route->ClearState(table, ts->GetListenerId());

--- a/src/bgp/routing-instance/service_chaining.h
+++ b/src/bgp/routing-instance/service_chaining.h
@@ -153,32 +153,24 @@ public:
 
     void FillServiceChainInfo(ShowServicechainInfo &info) const; 
 
-    void connected_table_unregistered() {
+    void set_connected_table_unregistered() {
         connected_table_unregistered_ = true;
     }
 
-    void dest_table_unregistered() {
+    void set_dest_table_unregistered() {
         dest_table_unregistered_ = true;
+    }
+
+    bool dest_table_unregistered() const {
+        return dest_table_unregistered_;
+    }
+
+    bool connected_table_unregistered() const {
+        return connected_table_unregistered_;
     }
 
     bool unregistered() const {
         return connected_table_unregistered_ && dest_table_unregistered_;
-    }
-
-    void set_dest_stopped() {
-        dest_stopped_ = true;
-    }
-
-    bool dest_stopped() const {
-        return dest_stopped_;
-    }
-
-    void set_connected_stopped() {
-        connected_stopped_ = true;
-    }
-
-    bool connected_stopped() const {
-        return connected_stopped_;
     }
 
     const ExtConnectRouteList &ext_connecting_routes() const {
@@ -213,8 +205,6 @@ private:
     ExtConnectRouteList ext_connect_routes_;
     bool connected_table_unregistered_;
     bool dest_table_unregistered_;
-    bool connected_stopped_;
-    bool dest_stopped_;
     bool aggregate_; // Whether the host route needs to be aggregated
     LifetimeRef<ServiceChain> src_table_delete_ref_;
 

--- a/src/bgp/routing-instance/static_route.h
+++ b/src/bgp/routing-instance/static_route.h
@@ -46,8 +46,12 @@ public:
         return static_route_map_;
     }
 private:
+    friend class StaticRouteTest;
     RoutingInstance *instance_;
     StaticRouteMap  static_route_map_;
+    void DisableQueue() { static_route_queue_->set_disable(true); }
+    void EnableQueue() { static_route_queue_->set_disable(false); }
+    bool IsQueueEmpty() { return static_route_queue_->IsQueueEmpty(); }
     WorkQueue<StaticRouteRequest *> *static_route_queue_;
     // Task trigger to resolve any pending static route config commit
     boost::scoped_ptr<TaskTrigger> resolve_trigger_;


### PR DESCRIPTION
Three issues identified.
1. Crash due to state missing
    Route is matched by the match condition and state is added before adding to WorkQueue.
    Route Entry gets deleted and delete request is added to Work Queue
    Route entry gets reused and Add request is now added to WorkQueue and subsequently the route entry gets deleted.
    When the work queue is processed with above 3 events, we can delete the MatchsTate with route still present in the WorkQueue.
2. Crash due to early unregister of DBClient even with DBState pending.
    When service chain config is deleted, the Unregister of the condition is done after Walk is completed. This event can occur before all MatchSTates are removed from the route. Due to this RemoveMAtchState function can possibly get called after the client is unregistered.
3. Concurrency issue in setting/accessing “stopped” flag of service chain object. It was set in the WalkDone function(in db:DBTable task) and flag is checked in Match function(Called from Notify in db:DBTable task). Since these two can be running in parallel (From different partition task), we can enqueue requests/set-state even after stopping the service chain. Which was the root cause calling unregister with MatchState set.

Solution:
To overcome the above issues,  I have made following fixes
1. Maintain a ref count on MatchState. Refcount is taken when the route is added to the work queue. RemoveMatchSTate is only called when refcount goes to zero. IF the route entry gets reused, recycle the state by resetting the delete flag
2. Track the number of MatchSTate added on a MatchCondition. UnregisterCondition is called only after all MatchStates are deleted.
3. Removed the "stopped" flag as the fix handles entries after the service chain is stopped.
4. added test cases which recreates the crashes. (One unregister with state pending and Missing Match state while handling add request).
