### PR TITLE
fix for https://bugs.launchpad.net/opencontrail/+bug/1297579

### DIFF
--- a/src/api-lib/vnc_api_lib.ini
+++ b/src/api-lib/vnc_api_lib.ini
@@ -10,6 +10,7 @@ BASE_URL = /
 ; Authentication settings (optional)
 [auth]
 ;AUTHN_TYPE = keystone
+;AUTHN_PROTOCOL = http
 ;AUTHN_SERVER = 127.0.0.1
 ;AUTHN_PORT = 35357
 ;AUTHN_URL = /v2.0/tokens


### PR DESCRIPTION
1. If the auth token is not specified, call to fetch auth token from keystone (_authenticate()) is done in try catch. In case of exception, give an error message “unable to authenticate”
2. If auth token is specified, and authentication fails, no attempt should be made to fetch token again. Instead return error.
3. Authentication protocol is made configurable(key stone access may be secured(https) or unsecured(http))
