### PR TITLE
DHCP Snoop is enabled for a port in fabric-vrf without IP address

### DIFF
--- a/src/vnsw/agent/ksync/interface_ksync.cc
+++ b/src/vnsw/agent/ksync/interface_ksync.cc
@@ -71,7 +71,7 @@ InterfaceKSyncEntry::InterfaceKSyncEntry(InterfaceKSyncObject *obj,
     if (type_ == Interface::VM_INTERFACE) {
         const VmInterface *vmitf = 
             static_cast<const VmInterface *>(intf);
-        if (vmitf->dhcp_snoop_ip()) {
+        if (vmitf->do_dhcp_relay()) {
             ip_ = vmitf->ip_addr().to_ulong();
         }
         network_id_ = vmitf->vxlan_id();
@@ -125,7 +125,7 @@ bool InterfaceKSyncEntry::Sync(DBEntry *e) {
 
     if (intf->type() == Interface::VM_INTERFACE) {
         VmInterface *vm_port = static_cast<VmInterface *>(intf);
-        if (vm_port->dhcp_snoop_ip()) {
+        if (vm_port->do_dhcp_relay()) {
             if (ip_ != vm_port->ip_addr().to_ulong()) {
                 ip_ = vm_port->ip_addr().to_ulong();
                 ret = true;

--- a/src/vnsw/agent/ksync/interface_scan.h
+++ b/src/vnsw/agent/ksync/interface_scan.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2013 Juniper Networks, Inc. All rights reserved.
  */
 
-#ifndef vnsw_agent_interface_scanner_f
+#ifndef vnsw_agent_interface_scanner_h
 #define vnsw_agent_interface_scanner_h
 
 #include <db/db_entry.h>

--- a/src/vnsw/agent/oper/interface.h
+++ b/src/vnsw/agent/oper/interface.h
@@ -190,6 +190,10 @@ struct InterfaceData : public AgentData {
 /////////////////////////////////////////////////////////////////////////////
 class InterfaceTable : public AgentDBTable {
 public:
+    typedef std::map<const std::string, Ip4Address> DhcpSnoopMap;
+    typedef std::map<const std::string, Ip4Address>::iterator DhcpSnoopIterator;
+    typedef std::pair<const std::string, Ip4Address> DhcpSnoopPair;
+
     InterfaceTable(DB *db, const std::string &name) :
         AgentDBTable(db, name), operdb_(NULL), agent_(NULL),
         walkid_(DBTableWalker::kInvalidWalkerId), index_table_() { 
@@ -234,6 +238,11 @@ public:
                                           std::string *vm_project_uuid);
     void VmPortToMetaDataIp(uint16_t ifindex, uint32_t vrfid, Ip4Address *addr);
 
+    // Dhcp Snoop Map entries
+    const Ip4Address GetDhcpSnoopEntry(const std::string &ifname);
+    void DeleteDhcpSnoopEntry(const std::string &ifname);
+    void AddDhcpSnoopEntry(const std::string &ifname, const Ip4Address &addr);
+
     // TODO : to remove this
     static InterfaceTable *GetInstance() { return interface_table_; }
     Agent *agent() const { return agent_; }
@@ -248,6 +257,7 @@ private:
     Agent *agent_;          // Cached entry
     DBTableWalker::WalkId walkid_;
     IndexVector<Interface> index_table_;
+    DhcpSnoopMap dhcp_snoop_map_;
     DISALLOW_COPY_AND_ASSIGN(InterfaceTable);
 };
 

--- a/src/vnsw/agent/oper/peer.h
+++ b/src/vnsw/agent/oper/peer.h
@@ -28,8 +28,8 @@ public:
     enum Type {
         BGP_PEER,
         ECMP_PEER,
-        LOCAL_PEER,
         LOCAL_VM_PEER,
+        LOCAL_PEER,
         LOCAL_VM_PORT_PEER,
         LINKLOCAL_PEER,
         NOVA_PEER

--- a/src/vnsw/agent/oper/test/SConscript
+++ b/src/vnsw/agent/oper/test/SConscript
@@ -37,11 +37,14 @@ if sys.platform != 'darwin':
 
     test_inet_interface = env.Program(target = 'test_inet_interface', source = ['test_inet_interface.cc'])
     env.Alias('src/vnsw/agent/oper/test:test_inet_interface', test_inet_interface)
+    test_fabric_interface = env.Program(target = 'test_fabric_interface', source = ['test_fabric_interface.cc'])
+    env.Alias('src/vnsw/agent/oper/test:test_fabric_interface', test_fabric_interface)
     oper_test_suite = [
+                       test_fabric_interface,
                        test_inet_interface,
                        test_intf,
-                       test_vrf_assign,
                        test_linklocal,
+                       test_vrf_assign,
                        ]
 
     test = env.TestSuite('agent-test', oper_test_suite)

--- a/src/vnsw/agent/oper/test/test_fabric_interface.cc
+++ b/src/vnsw/agent/oper/test/test_fabric_interface.cc
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+#include <sys/socket.h>
+#include <linux/netlink.h>
+#include <net/if.h>
+#include <linux/if_tun.h>
+#include <linux/if_packet.h>
+
+#include "testing/gunit.h"
+
+#include <boost/uuid/string_generator.hpp>
+
+#include <base/logging.h>
+#include <io/event_manager.h>
+#include <tbb/task.h>
+#include <base/task.h>
+
+#include <cmn/agent_cmn.h>
+
+#include "cfg/cfg_init.h"
+#include "cfg/cfg_interface.h"
+#include "oper/operdb_init.h"
+#include "controller/controller_init.h"
+#include "pkt/pkt_init.h"
+#include "services/services_init.h"
+#include "ksync/ksync_init.h"
+#include "oper/interface_common.h"
+#include "oper/nexthop.h"
+#include "route/route.h"
+#include "oper/vrf.h"
+#include "oper/mpls.h"
+#include "oper/vm.h"
+#include "oper/vn.h"
+#include "filter/acl.h"
+#include "openstack/instance_service_server.h"
+#include "test_cmn_util.h"
+#include "vr_types.h"
+#include <controller/controller_export.h> 
+#include <ksync/ksync_sock_user.h> 
+
+void RouterIdDepInit() {
+}
+
+class FabricInterfaceTest : public ::testing::Test {
+public:
+    virtual void SetUp() {
+        agent_ = Agent::GetInstance();
+        interface_table_ = agent_->GetInterfaceTable();
+        nh_table_ = agent_->GetNextHopTable();
+        vrf_table_ = agent_->GetVrfTable();
+        fabric_rt_table_ = agent_->GetDefaultInet4UnicastRouteTable();
+
+        intf_count_ = agent_->GetInterfaceTable()->Size();
+        nh_count_ = agent_->GetNextHopTable()->Size();
+        vrf_count_ = agent_->GetVrfTable()->Size();
+
+        strcpy(fabric_vrf_name_, agent_->GetDefaultVrf().c_str());
+        VmAddReq(1);
+        VmAddReq(2);
+    }
+
+    virtual void TearDown() {
+        VmDelReq(1);
+        VmDelReq(2);
+        WAIT_FOR(100, 1000, (interface_table_->Size() == intf_count_));
+        WAIT_FOR(100, 1000, (agent_->GetVrfTable()->Size() == vrf_count_));
+        WAIT_FOR(100, 1000, (agent_->GetNextHopTable()->Size() == nh_count_));
+        WAIT_FOR(100, 1000, (agent_->GetVmTable()->Size() == 0U));
+        WAIT_FOR(100, 1000, (agent_->GetVnTable()->Size() == 0U));
+    }
+
+    int intf_count_;
+    int nh_count_;
+    int vrf_count_;
+    Agent *agent_;
+    InterfaceTable *interface_table_;
+    NextHopTable *nh_table_;
+    Inet4UnicastAgentRouteTable *fabric_rt_table_;
+    VrfTable *vrf_table_;
+    char fabric_vrf_name_[64];
+};
+
+static void DhcpInterfaceSync(FabricInterfaceTest *t, int id,
+                              const char *ifname) {
+    DBRequest req(DBRequest::DB_ENTRY_ADD_CHANGE);
+    req.key.reset(new VmInterfaceKey(AgentKey::RESYNC, MakeUuid(id), ifname));
+    req.data.reset(new VmInterfaceIpAddressData());
+    t->interface_table_->Enqueue(&req);
+}
+
+static void CfgIntfSync(FabricInterfaceTest *t, int id, const char *cfg_name,
+                        int vn, int vm, const char *vrf_name, const char *ip,
+                        bool fab_port) {
+    DBRequest req(DBRequest::DB_ENTRY_ADD_CHANGE);
+    req.key.reset(new VmInterfaceKey(AgentKey::RESYNC, MakeUuid(id), cfg_name));
+
+    VmInterfaceConfigData *cfg_data = new VmInterfaceConfigData();
+    req.data.reset(cfg_data);
+    InterfaceData *data = static_cast<InterfaceData *>(cfg_data);
+    data->VmPortInit();
+
+    cfg_data->cfg_name_ = cfg_name;
+    cfg_data->vn_uuid_ = MakeUuid(vn);
+    cfg_data->vm_uuid_ = MakeUuid(vm);
+    cfg_data->vrf_name_ = vrf_name;
+    cfg_data->addr_ = Ip4Address::from_string(ip);
+    cfg_data->fabric_port_ = fab_port;
+    t->interface_table_->Enqueue(&req);
+}
+
+static void NovaDel(FabricInterfaceTest *t, int id) {
+    VmInterface::Delete(t->interface_table_, MakeUuid(id));
+}
+
+static void NovaIntfAdd(FabricInterfaceTest *t, int id, const char *name,
+                        const char *addr, const char *mac) {
+    IpAddress ip = Ip4Address::from_string(addr);
+    VmInterface::Add(t->interface_table_, MakeUuid(id), name, ip.to_v4(), mac,
+                     "", MakeUuid(kProjectUuid),
+                     VmInterface::kInvalidVlanId, Agent::NullString());
+}
+
+// Fabric port with IP Address 0.0.0.0. Needs dhcp_relay
+TEST_F(FabricInterfaceTest, zero_ip_1) {
+    VnAddReq(1, "vn1", 0, fabric_vrf_name_);
+    NovaIntfAdd(this, 1, "fabric1", "0.0.0.0", "00:00:00:00:00:01");
+    client->WaitForIdle();
+    WAIT_FOR(1000, 100, (VmPortInactive(1) == true));
+
+    CfgIntfSync(this, 1, "fabric1", 1, 1, fabric_vrf_name_, "0.0.0.0", true);
+    client->WaitForIdle();
+    VmInterface *intf = static_cast<VmInterface *>(VmPortGet(1));
+    EXPECT_TRUE(intf->do_dhcp_relay());
+
+    NovaDel(this, 1);
+    CfgIntfSync(this, 1, "fabric1", 0, 0, "", "0.0.0.0", true);
+    VnDelReq(1);
+    client->WaitForIdle();
+    EXPECT_FALSE(VmPortFind(1));
+}
+
+// Fabric port with IP Address 0.0.0.0. Needs dhcp_relay
+TEST_F(FabricInterfaceTest, zero_ip_2) {
+    VnAddReq(1, "vn1", 0, fabric_vrf_name_);
+    NovaIntfAdd(this, 1, "fabric1", "1.1.1.1", "00:00:00:00:00:01");
+    client->WaitForIdle();
+    WAIT_FOR(1000, 100, (VmPortInactive(1) == true));
+
+    CfgIntfSync(this, 1, "fabric1", 1, 1, fabric_vrf_name_, "0.0.0.0", true);
+    client->WaitForIdle();
+    VmInterface *intf = static_cast<VmInterface *>(VmPortGet(1));
+    EXPECT_TRUE(intf->do_dhcp_relay());
+
+    NovaDel(this, 1);
+    CfgIntfSync(this, 1, "fabric1", 0, 0, "", "0.0.0.0", true);
+    VnDelReq(1);
+    client->WaitForIdle();
+    EXPECT_FALSE(VmPortFind(1));
+}
+
+// Fabric port with IP Address != 0.0.0.0. Does not need dhcp_relay
+TEST_F(FabricInterfaceTest, non_zero_ip_1) {
+    VnAddReq(1, "vn1", 0, fabric_vrf_name_);
+    NovaIntfAdd(this, 1, "fabric1", "0.0.0.0", "00:00:00:00:00:01");
+    client->WaitForIdle();
+    WAIT_FOR(1000, 100, (VmPortInactive(1) == true));
+
+    CfgIntfSync(this, 1, "fabric1", 1, 1, fabric_vrf_name_, "1.1.1.1", true);
+    client->WaitForIdle();
+    VmInterface *intf = static_cast<VmInterface *>(VmPortGet(1));
+    EXPECT_TRUE(intf->do_dhcp_relay() == false);
+
+    NovaDel(this, 1);
+    CfgIntfSync(this, 1, "fabric1", 0, 0, "", "0.0.0.0", true);
+    VnDelReq(1);
+    client->WaitForIdle();
+    EXPECT_FALSE(VmPortFind(1));
+}
+
+// Fabric port with IP Address != 0.0.0.0. Does not need dhcp_relay
+TEST_F(FabricInterfaceTest, non_zero_ip_2) {
+    VnAddReq(1, "vn1", 0, fabric_vrf_name_);
+    NovaIntfAdd(this, 1, "fabric1", "1.1.1.1", "00:00:00:00:00:01");
+    client->WaitForIdle();
+    WAIT_FOR(1000, 100, (VmPortInactive(1) == true));
+
+    CfgIntfSync(this, 1, "fabric1", 1, 1, fabric_vrf_name_, "1.1.1.1", true);
+    client->WaitForIdle();
+    VmInterface *intf = static_cast<VmInterface *>(VmPortGet(1));
+    EXPECT_TRUE(intf->do_dhcp_relay() == false);
+
+    NovaDel(this, 1);
+    CfgIntfSync(this, 1, "fabric1", 0, 0, "", "0.0.0.0", true);
+    VnDelReq(1);
+    client->WaitForIdle();
+    EXPECT_FALSE(VmPortFind(1));
+}
+
+// Interface with IP == 0.0.0.0 on non-fabric VRF. Should not need dncp_relay
+TEST_F(FabricInterfaceTest, non_fabric_vrf_1) {
+    VrfAddReq("vrf1");
+    VnAddReq(1, "vn1", 0, "vrf1");
+    NovaIntfAdd(this, 1, "fabric1", "0.0.0.0", "00:00:00:00:00:01");
+    client->WaitForIdle();
+    WAIT_FOR(1000, 100, (VmPortInactive(1) == true));
+
+    CfgIntfSync(this, 1, "fabric1", 1, 1, "vrf1", "0.0.0.0", true);
+    client->WaitForIdle();
+    VmInterface *intf = static_cast<VmInterface *>(VmPortGet(1));
+    EXPECT_TRUE(intf->do_dhcp_relay() == false);
+
+    NovaDel(this, 1);
+    CfgIntfSync(this, 1, "fabric1", 0, 0, "", "0.0.0.0", true);
+    VnDelReq(1);
+    VrfDelReq("vrf1");
+    client->WaitForIdle();
+    EXPECT_FALSE(VmPortFind(1));
+}
+
+// Interface with IP != 0.0.0.0 on non-fabric VRF. Should not need dncp_relay
+TEST_F(FabricInterfaceTest, non_fabric_vrf_2) {
+    VrfAddReq("vrf1");
+    VnAddReq(1, "vn1", 0, "vrf1");
+    NovaIntfAdd(this, 1, "fabric1", "1.1.1.1", "00:00:00:00:00:01");
+    client->WaitForIdle();
+    WAIT_FOR(1000, 100, (VmPortInactive(1) == true));
+
+    CfgIntfSync(this, 1, "fabric1", 1, 1, "vrf1", "1.1.1.1", true);
+    client->WaitForIdle();
+    VmInterface *intf = static_cast<VmInterface *>(VmPortGet(1));
+    EXPECT_TRUE(intf->do_dhcp_relay() == false);
+
+    NovaDel(this, 1);
+    CfgIntfSync(this, 1, "fabric1", 0, 0, "", "0.0.0.0", true);
+    VnDelReq(1);
+    VrfDelReq("vrf1");
+    client->WaitForIdle();
+    EXPECT_FALSE(VmPortFind(1));
+}
+
+// port with IP Address 0.0.0.0 learning from DHCP Relay
+TEST_F(FabricInterfaceTest, dhcp_snoop_1) {
+    VnAddReq(1, "vn1", 0, fabric_vrf_name_);
+    NovaIntfAdd(this, 1, "fabric1", "0.0.0.0", "00:00:00:00:00:01");
+    client->WaitForIdle();
+    WAIT_FOR(1000, 100, (VmPortInactive(1) == true));
+
+    CfgIntfSync(this, 1, "fabric1", 1, 1, fabric_vrf_name_, "0.0.0.0", true);
+    client->WaitForIdle();
+    VmInterface *intf = static_cast<VmInterface *>(VmPortGet(1));
+    EXPECT_TRUE(intf->do_dhcp_relay());
+
+    interface_table_->AddDhcpSnoopEntry("fabric1",
+                                        Ip4Address::from_string("1.1.1.1"));
+    DhcpInterfaceSync(this, 1, "fabric1");
+    client->WaitForIdle();
+
+    EXPECT_TRUE(intf->do_dhcp_relay());
+    EXPECT_TRUE(intf->ip_addr().to_string() == "1.1.1.1");
+    Inet4UnicastRouteEntry *rt;
+    rt = RouteGet(fabric_vrf_name_, Ip4Address::from_string("1.1.1.1"), 32);
+    EXPECT_TRUE(rt != NULL);
+
+    interface_table_->AddDhcpSnoopEntry("fabric1",
+                                        Ip4Address::from_string("2.2.2.2"));
+    DhcpInterfaceSync(this, 1, "fabric1");
+    client->WaitForIdle();
+    rt = RouteGet(fabric_vrf_name_, Ip4Address::from_string("2.2.2.2"), 32);
+    EXPECT_TRUE(rt != NULL);
+    rt = RouteGet(fabric_vrf_name_, Ip4Address::from_string("1.1.1.1"), 32);
+    EXPECT_TRUE(rt == NULL);
+
+    NovaDel(this, 1);
+    CfgIntfSync(this, 1, "fabric1", 0, 0, "", "0.0.0.0", true);
+    VnDelReq(1);
+    client->WaitForIdle();
+    EXPECT_FALSE(VmPortFind(1));
+}
+
+int main(int argc, char **argv) {
+    GETUSERARGS();
+
+    client = TestInit(init_file, ksync_init, false, false, false);
+
+    int ret = RUN_ALL_TESTS();
+
+    usleep(10000);
+    client->WaitForIdle();
+    usleep(10000);
+
+    return ret;
+}

--- a/src/vnsw/agent/oper/vm_interface.h
+++ b/src/vnsw/agent/oper/vm_interface.h
@@ -182,7 +182,7 @@ public:
         vn_(NULL), ip_addr_(0), mdata_addr_(0), subnet_bcast_addr_(0),
         vm_mac_(""), policy_enabled_(false), mirror_entry_(NULL),
         mirror_direction_(MIRROR_RX_TX), cfg_name_(""), fabric_port_(true),
-        need_linklocal_ip_(false), dhcp_snoop_ip_(false), vm_name_(),
+        need_linklocal_ip_(false), do_dhcp_relay_(false), vm_name_(),
         vm_project_uuid_(nil_uuid()), vxlan_id_(0), layer2_forwarding_(true),
         ipv4_forwarding_(true), mac_set_(false), vlan_id_(kInvalidVlanId),
         parent_(NULL), sg_list_(), floating_ip_list_(), service_vlan_list_(),
@@ -200,7 +200,7 @@ public:
         vn_(NULL), ip_addr_(addr), mdata_addr_(0), subnet_bcast_addr_(0),
         vm_mac_(mac), policy_enabled_(false), mirror_entry_(NULL),
         mirror_direction_(MIRROR_RX_TX), cfg_name_(""), fabric_port_(true),
-        need_linklocal_ip_(false), dhcp_snoop_ip_(false), vm_name_(vm_name),
+        need_linklocal_ip_(false), do_dhcp_relay_(false), vm_name_(vm_name),
         vm_project_uuid_(vm_project_uuid), vxlan_id_(0),
         layer2_forwarding_(true), ipv4_forwarding_(true), mac_set_(false),
         vlan_id_(vlan_id), parent_(parent), sg_list_(), floating_ip_list_(),
@@ -235,7 +235,7 @@ public:
     const std::string &vm_mac() const { return vm_mac_; }
     bool fabric_port() const { return fabric_port_; }
     bool need_linklocal_ip() const { return  need_linklocal_ip_; }
-    bool dhcp_snoop_ip() const { return dhcp_snoop_ip_; }
+    bool do_dhcp_relay() const { return do_dhcp_relay_; }
     int vxlan_id() const { return vxlan_id_; }
     bool layer2_forwarding() const { return layer2_forwarding_; }
     bool ipv4_forwarding() const { return ipv4_forwarding_; }
@@ -279,7 +279,7 @@ public:
     void CopySgIdList(SecurityGroupList *sg_id_list) const;
     bool NeedMplsLabel() const;
     bool IsVxlanMode() const;
-    bool IsDhcpSnoopIp(std::string &name, Ip4Address *ip) const;
+    bool GetDhcpSnoopIp(const std::string &name, Ip4Address *ip) const;
     bool SgExists(const boost::uuids::uuid &id, const SgList &sg_l);
     bool IsMirrorEnabled() const { return mirror_entry_.get() != NULL; }
     bool HasFloatingIp() const { return floating_ip_list_.list_.size() != 0; }
@@ -401,8 +401,8 @@ private:
     std::string cfg_name_;
     bool fabric_port_;
     bool need_linklocal_ip_;
-    // true if IP is obtained from snooping DHCP from fabric, not from config
-    bool dhcp_snoop_ip_; 
+    // true if IP is to be obtained from DHCP Relay and not learnt from fabric
+    bool do_dhcp_relay_; 
     // VM-Name. Used by DNS
     std::string vm_name_;
     // project uuid of the vm to which the interface belongs
@@ -497,11 +497,8 @@ struct VmInterfaceAddData : public VmInterfaceData {
 
 // Structure used when type=IP_ADDR. Used to update IP-Address of VM-Interface
 struct VmInterfaceIpAddressData : public VmInterfaceData {
-    VmInterfaceIpAddressData(const Ip4Address &ip_addr) :
-        VmInterfaceData(IP_ADDR), ip_addr_(ip_addr) { }
+    VmInterfaceIpAddressData() : VmInterfaceData(IP_ADDR) { }
     virtual ~VmInterfaceIpAddressData() { }
-
-    Ip4Address ip_addr_;
 };
 
 // Structure used when type=IP_ADDR. Used to update IP-Address of VM-Interface

--- a/src/vnsw/agent/services/dhcp_handler.cc
+++ b/src/vnsw/agent/services/dhcp_handler.cc
@@ -62,9 +62,7 @@ bool DhcpHandler::Run() {
 
     // For VM interfaces in default VRF, if the config doesnt have IP address,
     // send the request to fabric
-    if (vm_itf_->vrf() &&
-        vm_itf_->vrf()->GetName() == agent()->GetDefaultVrf() &&
-        (!vm_itf_->ip_addr().to_ulong() || vm_itf_->dhcp_snoop_ip())) {
+    if (vm_itf_->vrf() && vm_itf_->do_dhcp_relay()) {
         RelayRequestToFabric();
         return true;
     }
@@ -453,12 +451,14 @@ void DhcpHandler::RelayResponseFromFabric() {
     }
 
     if (msg_type_ == DHCP_ACK) {
-        // Update the interface with the IP address, to trigger a route add
+        // Populate the DHCP Snoop table
+        agent()->GetInterfaceTable()->AddDhcpSnoopEntry
+            (vm_itf_->name(), Ip4Address(ntohl(dhcp_->yiaddr)));
+        // Enqueue RESYNC to update the IP address
         DBRequest req(DBRequest::DB_ENTRY_ADD_CHANGE);
         req.key.reset(new VmInterfaceKey(AgentKey::RESYNC, vm_itf_->GetUuid(),
                                          vm_itf_->name()));
-        req.data.reset(new VmInterfaceIpAddressData
-                       (Ip4Address(ntohl(dhcp_->yiaddr))));
+        req.data.reset(new VmInterfaceIpAddressData());
         agent()->GetInterfaceTable()->Enqueue(&req);
     }
 


### PR DESCRIPTION
Maintain DHCP Snoop table in interface table.
Use DHCP Snoop table to add IP address of interface
Support renew of DHCP from fabric port
Add test code for DHCP Snooping
