### PR TITLE
Adding the missing check to verify package is installed

### DIFF
--- a/src/config/utils/contrail-version-deb
+++ b/src/config/utils/contrail-version-deb
@@ -27,6 +27,7 @@ fi
 echo "Package                                Version                       Build-ID | Repo | Package Name"
 echo "-------------------------------------- ----------------------------- ----------------------------------"
 for i in `cat $CONTRAILRPMS`; do
+  dpkg -s $i 2> /dev/null 1> /dev/null
   ret_code=$?
   if [ $ret_code == 0 ]; then
       v="";


### PR DESCRIPTION
The to verify package is installed or not is missing in R1.05 branch. The check is already present in master branch. 

This missing check has introduced bug 2737 in Ubuntu. Adding the check back. 
