### PR TITLE
If admin_token is not specified in api_server.conf, let the default be N...

### DIFF
--- a/src/config/api-server/vnc_cfg_api_server.py
+++ b/src/config/api-server/vnc_cfg_api_server.py
@@ -532,7 +532,7 @@ class VncApiServer(VncApiServerGen):
 
         config = None
         if args.conf_file:
-            config = ConfigParser.SafeConfigParser()
+            config = ConfigParser.SafeConfigParser({'admin_token': None})
             config.read([args.conf_file])
             defaults.update(dict(config.items("DEFAULTS")))
             if 'multi_tenancy' in config.options('DEFAULTS'):


### PR DESCRIPTION
...one
