### PR TITLE
Handle case where BgpTable is deleted when processing subscribe.

### DIFF
--- a/src/bgp/bgp_peer_membership.cc
+++ b/src/bgp/bgp_peer_membership.cc
@@ -858,10 +858,11 @@ void PeerRibMembershipManager::NotifyCompletion(BgpTable *table,
 void PeerRibMembershipManager::ProcessRegisterRibEvent(BgpTable *table,
                                    MembershipRequestList *request_list) {
 
-    // Ignore if the table is already marked for deletion
+    // Notify completion right away if the table is marked for deletion
     if (table->IsDeleted()) {
-        register_request_map_.erase(table);
+        NotifyCompletion(table, request_list);
         delete request_list;
+        register_request_map_.erase(table);
         return;
     }
 

--- a/src/bgp/bgp_peer_membership.h
+++ b/src/bgp/bgp_peer_membership.h
@@ -227,6 +227,7 @@ public:
     void FillRegisteredTable(IPeer *peer, std::vector<std::string> &list);
 
 private:
+    friend class BgpXmppUnitTest;
     friend class PeerMembershipMgrTest;
     friend class PeerRibMembershipManagerTest;
 

--- a/src/bgp/bgp_xmpp_channel.cc
+++ b/src/bgp/bgp_xmpp_channel.cc
@@ -1247,12 +1247,14 @@ void BgpXmppChannel::ProcessEnetItem(string vrf_name,
 
 void BgpXmppChannel::DequeueRequest(const string &table_name,
                                     DBRequest *request) {
+    auto_ptr<DBRequest> ptr(request);
+
     BgpTable *table = static_cast<BgpTable *>
         (bgp_server_->database()->FindTable(table_name));
-    if (table == NULL) {
+    if (table == NULL || table->IsDeleted()) {
         return;
     }
-    auto_ptr<DBRequest> ptr(request);
+
     PeerRibMembershipManager *mgr = bgp_server_->membership_mgr();
     if (mgr && !mgr->PeerRegistered(peer_.get(), table)) {
         BGP_LOG_PEER(Event, Peer(), SandeshLevel::SYS_WARN, BGP_LOG_FLAG_ALL,
@@ -1374,7 +1376,8 @@ bool BgpXmppChannel::MembershipResponseHandler(std::string table_name) {
         return true;
     } else if (state.pending_req == SUBSCRIBE) {
         IPeerRib *rib = mgr->IPeerRibFind(peer_.get(), table);
-        rib->set_instance_id(state.instance_id);
+        if (rib)
+            rib->set_instance_id(state.instance_id);
     }
 
     for(DeferQ::iterator it = defer_q_.find(vrf_n_table);

--- a/src/bgp/bgp_xmpp_channel.h
+++ b/src/bgp/bgp_xmpp_channel.h
@@ -62,6 +62,7 @@ public:
 private:
     friend class BgpXmppChannelMock;
     friend class BgpXmppChannelManager;
+    friend class BgpXmppUnitTest;
     class XmppPeer;
     class PeerClose;
     class PeerStats;


### PR DESCRIPTION
Fix bug in membership manager that caused clients to wait forever
after requesting a register on a deleted table.  We now consider
the registration to be complete right away if the table's deleted
and invoke the client's completion routine.

Add tests to recreate the issue and verify the fix.
