### PR TITLE
Fix build break in xen

### DIFF
--- a/src/base/parse_object.h
+++ b/src/base/parse_object.h
@@ -9,7 +9,15 @@
 #include <string.h>
 #include <map>
 #ifndef __APPLE__
-#include <endian.h>
+#include <byteswap.h>
+#endif
+
+#ifdef __LITTLE_ENDIAN__
+#define be64_to_host(data) bswap_64(data)
+#define host_to_be64(data) bswap_64(data)
+#else
+#define be64_to_host(data) (data)
+#define host_to_be64(data) (data)
 #endif
 
 static inline uint32_t get_short(const uint8_t *data) {
@@ -58,7 +66,7 @@ static inline void put_value(uint8_t *data, int size, uint64_t value) {
 static inline double get_double(const uint8_t *data) {
     uint64_t *pp = (uint64_t *)data;
 #ifndef __APPLE__
-    uint64_t re = be64toh(*pp);
+    uint64_t re = be64_to_host(*pp);
 #else
     uint64_t re = *pp
 #endif
@@ -74,7 +82,7 @@ static inline void put_double(uint8_t *data, double value) {
     } x;
     x.d = value;
 #ifndef __APPLE__
-    *pp = htobe64(x.u64);
+    *pp = host_to_be64(x.u64);
 #else
     *pp = x.u64;
 #endif


### PR DESCRIPTION
Build breaks in xen ddk as endian.h does not have be64toh and its friends defined there.
Replace them with bswap_64 that does the same functionality

Signed-off-by: Anirban Chakraborty abchak@juniper.com
