### PR TITLE
Bug: 2688

### DIFF
--- a/src/analytics/ruleparser/contrail-dbutils
+++ b/src/analytics/ruleparser/contrail-dbutils
@@ -78,7 +78,7 @@ class LimitedSizeDict(OrderedDict):
         self.popitem(last=False)
 
 def upgrade_from_1_0_3():
-    print "Abt to upgrade.."
+    print "About to upgrade.."
     uuid_flow_dict = LimitedSizeDict(size_limit=100000)
     try:
         cf_index = pycassa.ColumnFamily(pool,'FlowTableSvnSip')
@@ -330,7 +330,7 @@ if (args.purge_db_threshold != None):
 if args.upgrade:
     #Iterate from the old ver to current version and call
     # all the upgrade functions in order
-    command = "contrail-version | grep 'contrail-config '|"
+    command = "contrail-version | grep 'contrail-analytics-venv '|"
     current_ver = (os.popen(command + " awk '{print $2}'").read()).split("-",1)[0]
     if (args.upgrade != None):
         old_ver = args.upgrade


### PR DESCRIPTION
This bug deals with migrating data when upgrade happens. This fix
initially takes care of 1.03-1.04 data upgrade required. It moves the contents
of the old index table in 1.03 to the new index table in 1.04
Run over each row-key in the index table.Lookup for the flow info in the
FlowRecord table and insert the information in the new table. After
update, truncate the old tables.
The db-utils take oldversion as its argument and runs through a chain of
upgrade functions to move the data.
Verified with a script which tested that all the rowkeys in old version table were present in 
new version table
