### PR TITLE
Test subscribe/unsubscribe to two different incarnations of instance.

### DIFF
--- a/src/bgp/bgp_xmpp_channel.cc
+++ b/src/bgp/bgp_xmpp_channel.cc
@@ -1518,16 +1518,16 @@ void BgpXmppChannel::ProcessSubscriptionRequest(
     if (!instance_mgr) {
         BGP_LOG_PEER(Membership, Peer(), SandeshLevel::SYS_WARN,
                      BGP_LOG_FLAG_ALL, BGP_PEER_DIR_NA,
-                     " ProcessSubscriptionRequest: Routing Instance Manager "
-                     "not found");
+                     "Routing Instance Manager not found");
         return;
     }
     RoutingInstance *rt_instance = instance_mgr->GetRoutingInstance(vrf_name);
     if (rt_instance == NULL) {
         BGP_LOG_PEER(Membership, Peer(), SandeshLevel::SYS_WARN,
                      BGP_LOG_FLAG_ALL, BGP_PEER_DIR_NA,
-                     " ReceiveUpdate: Routing Instance " <<
-                     vrf_name << " not found");
+                     "Routing Instance " << vrf_name <<
+                     " not found when processing " <<
+                     (add_change ? "subscribe" : "unsubscribe"));
         if (add_change) {
             vrf_membership_request_map_[vrf_name] = instance_id;
         } else {
@@ -1546,8 +1546,9 @@ void BgpXmppChannel::ProcessSubscriptionRequest(
     if (rt_instance->deleted()) {
         BGP_LOG_PEER(Membership, Peer(), SandeshLevel::SYS_DEBUG,
                      BGP_LOG_FLAG_ALL, BGP_PEER_DIR_NA,
-                     " ReceiveUpdate: Routing Instance " <<
-                     vrf_name << " is being deleted");
+                     "Routing Instance " << vrf_name <<
+                     " is being deleted when processing " <<
+                     (add_change ? "subscribe" : "unsubscribe"));
         if (add_change) {
             vrf_membership_request_map_[vrf_name] = instance_id;
             return;


### PR DESCRIPTION
The first subscribe/unsubscribe are processed after the table has been
marked as deleted but has not yet been destroyed. The second subscribe
is received before the table and instance have been destroyed. Later,
the old table and instance are destroyed and new incarnations created.
The subscribe needs to happen on the new incarnation.
