### PR TITLE
Change to do LPM check while looking up a route from Floating-IP

### DIFF
--- a/src/vnsw/agent/pkt/test/test_pkt_flow.cc
+++ b/src/vnsw/agent/pkt/test/test_pkt_flow.cc
@@ -1664,8 +1664,7 @@ TEST_F(FlowTest, FlowOnDeletedVrf) {
     //Flow find should fail as interface is delete marked
     FlowEntry *fe = FlowGet(vrf_id, "11.1.1.3", vm1_ip,
                             IPPROTO_TCP, 30, 40);
-    EXPECT_TRUE(fe != NULL);
-    EXPECT_TRUE(fe->is_flags_set(FlowEntry::ShortFlow) == true);
+    EXPECT_TRUE(fe != NULL && fe->is_flags_set(FlowEntry::ShortFlow) == true);
 
     DeleteVmportEnv(input, 1, false);
     client->WaitForIdle();


### PR DESCRIPTION
- prefer local route over route from Floating-IP if LPM match
  against local route.
- prefer Floating-IP over local route for same prefix length
- prefer Floating-IP fip1 over fip2 based on vrf_name and addr.
