### PR TITLE
* When a flow transition happens from non ecmp to ecmp, forward flow

### DIFF
--- a/src/vnsw/agent/ksync/flowtable_ksync.cc
+++ b/src/vnsw/agent/ksync/flowtable_ksync.cc
@@ -39,7 +39,7 @@ FlowTableKSyncEntry::FlowTableKSyncEntry(FlowTableKSyncObject *obj,
     : flow_entry_(fe), hash_id_(hash_id), 
     old_reverse_flow_id_(FlowEntry::kInvalidFlowHandle), old_action_(0), 
     old_component_nh_idx_(0xFFFF), old_first_mirror_index_(0xFFFF), 
-    old_second_mirror_index_(0xFFFF), trap_flow_(false), nh_(NULL), 
+    old_second_mirror_index_(0xFFFF), trap_flow_(false), ecmp_(false), nh_(NULL),
     ksync_obj_(obj) {
 }
 
@@ -289,6 +289,12 @@ bool FlowTableKSyncEntry::Sync() {
         trap_flow_ = flow_entry_->is_flags_set(FlowEntry::Trap);
         changed = true;
     }
+
+    if (ecmp_ != flow_entry_->is_flags_set(FlowEntry::EcmpFlow)) {
+        ecmp_ = flow_entry_->is_flags_set(FlowEntry::EcmpFlow);
+        changed = true;
+    }
+
 
     if (flow_entry_->data().nh_state_.get() && 
         flow_entry_->data().nh_state_->nh()) {

--- a/src/vnsw/agent/ksync/flowtable_ksync.h
+++ b/src/vnsw/agent/ksync/flowtable_ksync.h
@@ -53,6 +53,7 @@ private:
     uint32_t old_first_mirror_index_;
     uint32_t old_second_mirror_index_;
     uint32_t trap_flow_;
+    bool ecmp_;
     KSyncEntryPtr nh_;
     FlowTableKSyncObject *ksync_obj_;
     DISALLOW_COPY_AND_ASSIGN(FlowTableKSyncEntry);


### PR DESCRIPTION
  and reverse flow have to be linked for RPF verification. Reverse flow's
  binding to forward flow was not programmed by agent since in ksync
  we wernt checking for ecmp flag change, and since all other fields would be same
  agent was not linking reverse flow to forward flow. Checking if ecmp flag has changed
  and forcing kernel programming
