### PR TITLE
Assert on duplicate enqueue of same task pointer

### DIFF
--- a/src/base/task.cc
+++ b/src/base/task.cc
@@ -406,6 +406,8 @@ void TaskScheduler::Enqueue(Task *t) {
 }
 
 void TaskScheduler::EnqueueUnLocked(Task *t) {
+    // Ensure that task is enqueued only once.
+    assert(t->GetSeqno() == 0);
     t->SetSeqNo(++seqno_);
     TaskGroup *group = GetTaskGroup(t->GetTaskId());
 
@@ -515,7 +517,10 @@ void TaskScheduler::OnTaskExit(Task *t) {
         return;
     }
 
+    // Task is being recycled, reset the state, seq_no and TBB task handle
     t->task_impl_ = NULL;
+    t->SetSeqNo(0);
+    t->state_ = Task::INIT;
     EnqueueUnLocked(t);
 }
 


### PR DESCRIPTION
The root cause for vizd crash in http://10.84.5.133/bugs/show_bug.cgi?id=2811 is CdbIf::CleanupTask was enqueued twice with same task pointer due to concurrent threads executing DB_Uninit

To detect this problem state sooner, an assert if the Task pointer is enqueued twice.
