### PR TITLE
Add local identifier and local AS to BgpNeighborConfig.

### DIFF
--- a/src/bgp/bgp_config.cc
+++ b/src/bgp/bgp_config.cc
@@ -286,6 +286,14 @@ BgpNeighborConfig::BgpNeighborConfig(const BgpInstanceConfig *instance,
     if (session != NULL) {
         SetSessionAttributes(local_name, session);
     }
+
+    // Get the local identifier and local as from the protocol config.
+    const BgpProtocolConfig *protocol = instance->protocol_config();
+    if (protocol && protocol->bgp_router()) {
+        const autogen::BgpRouterParams &params = protocol->router_params();
+        local_identifier_ = params.identifier;
+        local_as_ = params.autonomous_system;
+    }
 }
 
 //
@@ -356,12 +364,13 @@ bool BgpNeighborConfig::operator!=(const BgpNeighborConfig &rhs) const {
 }
 
 //
-// Update BgpNeighborConfig with the new values of autogen::BgoRouterParams
-// and autogen::BgpSessionAttributes.
+// Update BgpNeighborConfig from the supplied value.
 //
 void BgpNeighborConfig::Update(const BgpNeighborConfig *rhs) {
     peer_config_ = rhs->peer_config_;
     attributes_ = rhs->attributes_;
+    local_as_ = rhs->local_as_;
+    local_identifier_ = rhs->local_identifier_;
 }
 
 string BgpNeighborConfig::InstanceName() const {
@@ -596,6 +605,7 @@ void BgpInstanceConfig::AddNeighbor(BgpConfigManager *manager,
         neighbor->session_attributes().address_families.end());
     BGP_CONFIG_LOG_NEIGHBOR(Create, manager->server(), neighbor,
         SandeshLevel::SYS_DEBUG, BGP_LOG_FLAG_ALL,
+        neighbor->local_identifier(), neighbor->local_as(),
         neighbor->peer_address(), neighbor->peer_as(), families);
     neighbors_.insert(make_pair(neighbor->name(), neighbor));
     manager->Notify(neighbor, BgpConfigManager::CFG_ADD);
@@ -611,6 +621,7 @@ void BgpInstanceConfig::ChangeNeighbor(BgpConfigManager *manager,
         neighbor->session_attributes().address_families.end());
     BGP_CONFIG_LOG_NEIGHBOR(Update, manager->server(), neighbor,
         SandeshLevel::SYS_DEBUG, BGP_LOG_FLAG_ALL,
+        neighbor->local_identifier(), neighbor->local_as(),
         neighbor->peer_address(), neighbor->peer_as(), families);
     manager->Notify(neighbor, BgpConfigManager::CFG_CHANGE);
 }

--- a/src/bgp/bgp_config.h
+++ b/src/bgp/bgp_config.h
@@ -96,6 +96,8 @@ public:
 
     const std::string &name() const { return name_; }
     const std::string &uuid() const { return uuid_; }
+    as_t local_as() const { return (as_t) local_as_; }
+    const std::string local_identifier() const { return local_identifier_; }
     as_t peer_as() const { return (as_t) peer_config_.autonomous_system; }
     std::string peer_address() const { return peer_config_.address; }
     const std::string &vendor() const { return peer_config_.vendor; }
@@ -114,6 +116,8 @@ private:
     static AddressFamilyList default_addr_family_list_;
     std::string name_;
     std::string uuid_;
+    int local_as_;
+    std::string local_identifier_;
 
     DISALLOW_COPY_AND_ASSIGN(BgpNeighborConfig);
 };

--- a/src/bgp/bgp_log.sandesh
+++ b/src/bgp/bgp_log.sandesh
@@ -121,6 +121,10 @@ systemlog sandesh BgpConfigInstanceUpdateLog {
 trace sandesh BgpConfigNeighborCreateTrace {
     1: "Neighbor";
     2: string name;
+    9: "Local Identifier";
+    10: string local_identifier;
+    11: "Local AS";
+    12: i32 local_as;
     7: "Peer Address";
     8: string address;
     3: "Peer AS";
@@ -132,6 +136,10 @@ trace sandesh BgpConfigNeighborCreateTrace {
 systemlog sandesh BgpConfigNeighborCreateLog {
     1: "Neighbor";
     2: string name;
+    9: "Local Identifier";
+    10: string local_identifier;
+    11: "Local AS";
+    12: i32 local_as;
     7: "Peer Address";
     8: string address;
     3: "Peer AS";
@@ -153,6 +161,10 @@ systemlog sandesh BgpConfigNeighborDeleteLog {
 trace sandesh BgpConfigNeighborUpdateTrace {
     1: "Neighbor";
     2: string name;
+    9: "Local Identifier";
+    10: string local_identifier;
+    11: "Local AS";
+    12: i32 local_as;
     7: "Peer Address";
     8: string address;
     3: "Peer AS";
@@ -164,6 +176,10 @@ trace sandesh BgpConfigNeighborUpdateTrace {
 systemlog sandesh BgpConfigNeighborUpdateLog {
     1: "Neighbor";
     2: string name;
+    9: "Local Identifier";
+    10: string local_identifier;
+    11: "Local AS";
+    12: i32 local_as;
     7: "Peer Address";
     8: string address;
     3: "Peer AS";

--- a/src/bgp/testdata/config_test_31.xml
+++ b/src/bgp/testdata/config_test_31.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <routing-instance name='default-domain:default-project:ip-fabric:__default__'>
+      <bgp-router name='local'>
+          <address>10.1.1.100</address>
+          <autonomous-system>100</autonomous-system>
+      </bgp-router>
+      <bgp-router name='remote1'>
+          <address>10.1.1.1</address>
+          <autonomous-system>101</autonomous-system>
+      </bgp-router>
+      <bgp-router name='remote2'>
+          <address>10.1.1.2</address>
+          <autonomous-system>102</autonomous-system>
+      </bgp-router>
+      <bgp-router name='remote3'>
+          <address>10.1.1.3</address>
+          <autonomous-system>103</autonomous-system>
+      </bgp-router>
+    </routing-instance>
+</config>


### PR DESCRIPTION
A change in the local identifier or local AS for the
bgp-router triggers an update of all the bgp-peerings,
which in turn triggers update of BgpNeighborConfigs.

Add tests to verify that changes to identifier and AS
in the bgp-router are propagated to BgpNeighborConfigs.
