### PR TITLE
Make parse error handling in BgpConfigParser less forgiving.

### DIFF
--- a/src/bgp/test/bgp_xmpp_evpn_test.cc
+++ b/src/bgp/test/bgp_xmpp_evpn_test.cc
@@ -1085,7 +1085,6 @@ static const char *config_template_12 = "\
     <bgp-router name=\'X\'>\
         <identifier>192.168.0.1</identifier>\
         <address>127.0.0.1</address>\
-        <port>%d</port>\
     </bgp-router>\
     <virtual-network name='blue'>\
         <network-id>1</network-id>\

--- a/src/bgp/test/xmpp_ecmp_test.cc
+++ b/src/bgp/test/xmpp_ecmp_test.cc
@@ -193,6 +193,7 @@ const char *XmppEcmpTest::config_tmpl = "\
         <identifier>192.168.0.1</identifier>\
         <address>127.0.0.1</address>\
         <port>%d</port>\
+        <autonomous-system>64512</autonomous-system>\
         <session to=\'B\'>\
             <address-families>\
                 <family>e-vpn</family>\
@@ -205,6 +206,7 @@ const char *XmppEcmpTest::config_tmpl = "\
         <identifier>192.168.0.2</identifier>\
         <address>127.0.0.1</address>\
         <port>%d</port>\
+        <autonomous-system>64512</autonomous-system>\
         <session to=\'A\'>\
             <address-families>\
                 <family>e-vpn</family>\
@@ -213,7 +215,14 @@ const char *XmppEcmpTest::config_tmpl = "\
             </address-families>\
         </session>\
     </bgp-router>\
+    <virtual-network name='red-vn'>\
+        <network-id>101</network-id>\
+    </virtual-network>\
+    <virtual-network name='blue-vn'>\
+        <network-id>102</network-id>\
+    </virtual-network>\
     <routing-instance name='red'>\
+        <virtual-network>red-vn</virtual-network>\
         <vrf-target>target:1:1</vrf-target>\
         <vrf-target>\
             target:1:2\
@@ -221,6 +230,7 @@ const char *XmppEcmpTest::config_tmpl = "\
         </vrf-target>\
     </routing-instance>\
     <routing-instance name='blue'>\
+        <virtual-network>blue-vn</virtual-network>\
         <vrf-target>target:1:2</vrf-target>\
         <vrf-target>\
             target:1:1\
@@ -230,14 +240,9 @@ const char *XmppEcmpTest::config_tmpl = "\
 </config>\
 ";
 
+
 // Initialize mock agents and from xmpp sessions with the control-node.
 void XmppEcmpTest::Initialize() {
-    node_a_->bgp_server()->Configure(config_tmpl);
-    task_util::WaitForIdle();
-
-    node_b_->bgp_server()->Configure(config_tmpl);
-    task_util::WaitForIdle();
-
     const char *ri_1 = "red";
     const char *ri_2 = "blue";
 


### PR DESCRIPTION
Note that BgpConfigParser should be treated as test code rather
than production code. Hence it's better to flag errors and fail
instead of ignoring them. Allows errors in tests to be detected
more easily.

Fix a couple of tests that had bad configuration.
