### PR TITLE
Add tests to simulate failures in BgpSessionManager::CreateSession.

### DIFF
--- a/src/bgp/bgp_session_manager.cc
+++ b/src/bgp/bgp_session_manager.cc
@@ -33,13 +33,10 @@ TcpSession *BgpSessionManager::CreateSession() {
 
     boost::system::error_code ec;
     socket->open(ip::tcp::v4(), ec);
-    if (ec) {
+    if (ec || (ec = session->SetSocketOptions()) || socket_open_failure()) {
         BGP_LOG_STR(BgpMessage, SandeshLevel::SYS_WARN, BGP_LOG_FLAG_ALL,
-                    "open failed: " << ec.message());
-        return NULL;
-    }
-    ec = session->SetSocketOptions();
-    if (ec) {
+            "Failed to open bgp socket, error: " << ec.message());
+        DeleteSession(session);
         return NULL;
     }
     return session;

--- a/src/bgp/bgp_session_manager.h
+++ b/src/bgp/bgp_session_manager.h
@@ -28,7 +28,7 @@ public:
     BgpServer *server() {
         return server_;
     }
-    
+
 protected:
     virtual TcpSession *AllocSession(Socket *socket);
     virtual bool AcceptSession(TcpSession *session);

--- a/src/bgp/state_machine.h
+++ b/src/bgp/state_machine.h
@@ -143,6 +143,7 @@ public:
     BgpSession *passive_session();
     void set_passive_session(BgpSession *session);
 
+    int connect_attempts() const { return attempts_; }
     void connect_attempts_inc() { attempts_++; }
     void connect_attempts_clear() { attempts_ = 0; }
 

--- a/src/io/tcp_server.cc
+++ b/src/io/tcp_server.cc
@@ -17,7 +17,7 @@ using namespace boost::asio::ip;
 using namespace std;
 
 TcpServer::TcpServer(EventManager *evm)
-    : evm_(evm) {
+    : evm_(evm), socket_open_failure_(false) {
     refcount_ = 0;
     TcpServerManager::AddServer(this);
 }

--- a/src/io/tcp_server.h
+++ b/src/io/tcp_server.h
@@ -20,7 +20,7 @@ class TcpSession;
 class TcpServerSocketStats;
 
 class TcpServer {
-  public:
+public:
     typedef boost::asio::ip::tcp::endpoint Endpoint;
     typedef boost::asio::ip::tcp::socket Socket;
 
@@ -98,10 +98,10 @@ class TcpServer {
     void GetRxSocketStats(TcpServerSocketStats &socket_stats) const;
     void GetTxSocketStats(TcpServerSocketStats &socket_stats) const;
 
-  protected:
+protected:
     // Create a session object.
     virtual TcpSession *AllocSession(Socket *socket) = 0;
-    
+
     //
     // Passively accepted a new session. Returns true if the session is
     // accepted, false otherwise.
@@ -111,13 +111,19 @@ class TcpServer {
     //
     virtual bool AcceptSession(TcpSession *session);
 
+    // For testing - will typically be used by derived class.
+    void set_socket_open_failure(bool flag) { socket_open_failure_ = flag; }
+    bool socket_open_failure() const { return socket_open_failure_; }
+
     Endpoint LocalEndpoint() const;
 
-  private:
+private:
     friend class TcpSession;
     friend class TcpMessageWriter;
+    friend class BgpServerUnitTest;
     friend void intrusive_ptr_add_ref(TcpServer *server);
     friend void intrusive_ptr_release(TcpServer *server);
+
     typedef boost::intrusive_ptr<TcpServer> TcpServerPtr;
     typedef boost::intrusive_ptr<TcpSession> TcpSessionPtr;
     struct TcpSessionPtrCmp {
@@ -153,7 +159,8 @@ class TcpServer {
     boost::scoped_ptr<boost::asio::ip::tcp::acceptor> acceptor_;
     tbb::atomic<int> refcount_;
     std::string name_;
-    
+    bool socket_open_failure_;
+
     DISALLOW_COPY_AND_ASSIGN(TcpServer);
 };
 


### PR DESCRIPTION
Simulate socket open failure in BgpSessionManager::CreateSession.
Simulate unknown failure in BgpSessionManager::CreateSession.
