### PR TITLE
increase the default timeout of 20 secs. 

### DIFF
--- a/src/config/common/zkclient.py
+++ b/src/config/common/zkclient.py
@@ -134,6 +134,7 @@ class ZookeeperClient(object):
         self._zk_client = \
             kazoo.client.KazooClient(
                 server_list,
+                timeout=20,
                 handler=kazoo.handlers.gevent.SequentialGeventHandler(),
                 logger=logger)
 


### PR DESCRIPTION
The heartbeats are expected to be sent every 1/3 the timeout interval and response received within 1/3 timeout. We have seen the writes to disk take as high as 5-6 secs and hence heartbeat response missed and reconnects.

https://github.com/python-zk/kazoo/issues/66
