### PR TITLE
Don't make TaskScheduler recycle the task when WorkQueue is disabled.

### DIFF
--- a/src/base/queue_task.h
+++ b/src/base/queue_task.h
@@ -40,8 +40,8 @@ public:
 
 private:
     bool RunQueue() {
-        // Running is done if queue_ is disabled
-        if (queue_->IsDisabled()) {
+        // Check if we need to abort
+        if (queue_->RunnerAbort()) {
             return queue_->RunnerDone();
         }
 
@@ -113,6 +113,7 @@ public:
         callback_(callback),
         on_entry_cb_(0),
         on_exit_cb_(0),
+        start_runner_(0),
         current_runner_(NULL),
         on_entry_defer_count_(0),
         disabled_(false),
@@ -333,6 +334,10 @@ private:
         }
         drops_++;
         return false;
+    }
+
+    bool RunnerAbort() {
+        return (disabled_ || (!start_runner_.empty() && !start_runner_()));
     }
 
     bool RunnerDone() {

--- a/src/base/test/queue_task_test.cc
+++ b/src/base/test/queue_task_test.cc
@@ -262,7 +262,7 @@ TEST_F(QueueTaskTest, WaterMarkTest) {
     work_queue_.SetStartRunnerFunc(
         boost::bind(&QueueTaskTest::StartRunnerAlways, this));
     SetWorkQueueMaxIterations(6);
-    work_queue_.SetEntryCallback(
+    work_queue_.SetExitCallback(
         boost::bind(&QueueTaskTest::DequeueTaskReady, this, false));
     work_queue_.MayBeStartRunner();
     task_util::WaitForIdle(1);
@@ -272,7 +272,7 @@ TEST_F(QueueTaskTest, WaterMarkTest) {
     work_queue_.SetStartRunnerFunc(
         boost::bind(&QueueTaskTest::StartRunnerAlways, this));
     SetWorkQueueMaxIterations(1);
-    work_queue_.SetEntryCallback(
+    work_queue_.SetExitCallback(
         boost::bind(&QueueTaskTest::DequeueTaskReady, this, false));
     work_queue_.MayBeStartRunner();
     task_util::WaitForIdle(1);


### PR DESCRIPTION
The previous behaviour didn't let tests use task_util::WaitForIdle()
after disabling a WorkQueue since the QueueRunnerTask was constantly
being recycled.
