### PR TITLE
[geventhttpclient] Remove strong dependency to geventhttpclient>=1.0a

### DIFF
--- a/src/config/api-server/setup.py
+++ b/src/config/api-server/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         'lxml>=2.3.2',
         'gevent==0.13.6',
-        'geventhttpclient==1.0a',
+        'geventhttpclient>=1.0a',
         'pycassa>=1.7.2',
         'netaddr>=0.7.5',
         'bitarray==0.8.0',


### PR DESCRIPTION
We can remove the strong dependency on 1.0a, Deepinder Setia manage this
fix in https://bugs.launchpad.net/opencontrail/+bug/1306715

Refs: http://lists.opencontrail.org/pipermail/dev_lists.opencontrail.org/2014-April/000930.html

And already merged in Juniper/contrail-third-party#16
And for packaging Juniper/contrail-packages#31
