### PR TITLE
Fix issues reported in bug #1310804 comments

### DIFF
--- a/src/vnsw/contrail-vrouter-api/contrail_vrouter_api/tests/test_vrouter_api.py
+++ b/src/vnsw/contrail-vrouter-api/contrail_vrouter_api/tests/test_vrouter_api.py
@@ -28,13 +28,14 @@ class VRouterApiTest(unittest.TestCase):
             name='rpc_client_instance')
         self._api._rpc_client_instance.return_value = mock_client
 
-        vm_uuid = str(uuid.uuid1())
-        vif_uuid = str(uuid.uuid1())
-        self._api.add_port(vm_uuid, vif_uuid, 'tapX', 'aa:bb:cc:ee:ff:00')
+        vm_uuid = uuid.uuid1()
+        vif_uuid = uuid.uuid1()
+        self._api.add_port(str(vm_uuid), str(vif_uuid), 'tapX',
+                           'aa:bb:cc:ee:ff:00')
         self.assertTrue(mock_client.AddPort.called)
         self.assertTrue(self._api._ports[vif_uuid])
 
-        self._api.delete_port(vif_uuid)
+        self._api.delete_port(str(vif_uuid))
         self.assertTrue(mock_client.DeletePort.called)
 
     def test_resynchronize(self):
@@ -50,3 +51,22 @@ class VRouterApiTest(unittest.TestCase):
         self._api._rpc_client_instance.return_value = mock_client
         self._api.periodic_connection_check()
         self.assertTrue(mock_client.AddPort.called)
+
+    def test_additional_arguments(self):
+        mock_client = mock.Mock()
+        self._api._rpc_client_instance = mock.MagicMock(
+            name='rpc_client_instance')
+        self._api._rpc_client_instance.return_value = mock_client
+        vif_uuid = uuid.uuid1()
+        network_uuid = uuid.uuid1()
+        project_uuid = uuid.uuid1()
+        self._api.add_port(str(uuid.uuid1()), str(vif_uuid), 'tapX',
+                           'aa:bb:cc:ee:ff:00',
+                           network_uuid=str(network_uuid),
+                           vm_project_uuid=str(project_uuid))
+        self.assertTrue(mock_client.AddPort.called)
+        port = self._api._ports[vif_uuid]
+        self.assertEqual(self._api._uuid_to_hex(network_uuid),
+                         port.vn_id)
+        self.assertEqual(self._api._uuid_to_hex(project_uuid),
+                         port.vm_project_uuid)


### PR DESCRIPTION
Remove invalid call to Client.open();
Make sure that all uuids are treated as strings;
Internally implement port uuid key as an object so that the key doesn't
depend on whether the caller is using dashes or not in the uuid string.
