### PR TITLE
Correct use of fq name

### DIFF
--- a/src/config/svc-monitor/svc_monitor.py
+++ b/src/config/svc-monitor/svc_monitor.py
@@ -446,12 +446,7 @@ class SvcMonitor(object):
             else:
                 funcname = "get_" + itf_type + "_virtual_network"
                 func = getattr(si_props, funcname)
-                vn_fq_name_str = func()
-
-            vn_fq_name = None
-            if vn_fq_name_str:
-                domain, proj, vn_name = vn_fq_name_str.split(':')
-                vn_fq_name = [domain, proj, vn_name]
+                vn_fq_name = func()
 
             if itf_type in _SVC_VNS:
                 vn_id = self._get_vn_id(proj_obj, vn_fq_name,
@@ -572,7 +567,7 @@ class SvcMonitor(object):
             else:
                 funcname = "get_" + itf_type + "_virtual_network"
                 func = getattr(si_props, funcname)
-                si_vn_str = func()
+                si_vn_str = ':'.join(func())
             if not si_vn_str:
                 continue
 

--- a/src/config/utils/service-instance.py
+++ b/src/config/utils/service-instance.py
@@ -36,6 +36,14 @@ class ServiceInstanceCmd(object):
                             self._args.instance_name]
         self._st_fq_name = [self._args.domain_name, self._args.template_name]
         self._domain_fq_name = [self._args.domain_name]
+
+        self._mgmt_vn_fq_name = None
+        self._left_vn_fq_name = None
+        self._right_vn_fq_name = None
+        if self._args.mgmt_vn:
+            self._mgmt_vn_fq_name = [self._args.domain_name,
+                                     self._args.proj_name,
+                                     self._args.mgmt_vn]
         if self._args.left_vn:
             self._left_vn_fq_name = [self._args.domain_name,
                                      self._args.proj_name,
@@ -183,9 +191,9 @@ class ServiceInstanceCmd(object):
             si_uuid = self._vnc_lib.service_instance_create(si_obj)
 
         si_prop = ServiceInstanceType(
-            left_virtual_network=self._args.left_vn,
-            management_virtual_network=self._args.mgmt_vn,
-            right_virtual_network=self._args.right_vn)
+            left_virtual_network=self._left_vn_fq_name,
+            management_virtual_network=self._mgmt_vn_fq_name,
+            right_virtual_network=self._right_vn_fq_name)
 
         # set scale out
         scale_out = ServiceScaleOutType(


### PR DESCRIPTION
- use fq_name_string for virtual networks attribute in service instance properties
  object in the utils service-instance.py script
- use fq name in the SVC monitor service
