### PR TITLE
Install opserver and sandesh_common as regular packages and not as pip p...

### DIFF
--- a/src/opserver/test/SConscript
+++ b/src/opserver/test/SConscript
@@ -60,15 +60,15 @@ pip_pkgs = ['greenlet==0.4.1', 'gevent==0.13.8', 'eventlet==0.9.17',
         'testtools==0.9.21', 'fixtures==0.3.12', 'requests==1.1.0',
         'lxml==2.3.3', 'geventhttpclient==1.0a', 'prettytable==0.7.2',
         'psutil==0.4.1', 'redis==2.7.1', 'xmltodict==0.2', 'thrift==0.8.0',
-        'bottle==0.11.6',
-        Dir(env['TOP']).abspath + '/opserver/dist/opserver-0.1dev.tar.gz',
-        Dir(env['TOP']).abspath + '/sandesh/common/dist/sandesh-common-0.1dev.tar.gz']
+        'bottle==0.11.6']
 
 build_pkgs = [
         '#controller/src/analytics/test/utils/mockcassandra',
         '#controller/src/analytics/test/utils/mockredis',
+        '#controller/src/opserver/test',
         env['TOP'] + '/tools/sandesh/library/python',
-        '#controller/src/opserver/test']
+        env['TOP'] + '/sandesh/common',
+        env['TOP'] + '/opserver']
 
 #venv that we are building is in env['analytics_test']
 env.Depends (env['analytics_test'], env['OPSERVER_PKG'])


### PR DESCRIPTION
...ackage in analytics_test virtual environment. pip packages seem to get updated only if there is a change in the version. Therefore, opserver package doesn't get updated in venv even if any change is made in opserver. 
