### PR TITLE
Nexthop notification server functionality in vrouter agent

### DIFF
--- a/src/io/SConscript
+++ b/src/io/SConscript
@@ -18,6 +18,11 @@ except_env.Append(CPPPATH = env['TOP_INCLUDE'] + '/thrift')
 except_env.Append(CPPPATH = [env['TOP']])
 EventManagerSrc = except_env.Object('event_manager.o', 'event_manager.cc')
 
+usock_env = BuildEnv.Clone()
+usock_env.CppEnableExceptions()
+usock_env.Append(CPPPATH = env['TOP'])
+usock_server = usock_env.Object('usock_server.o', 'usock_server.cc')
+
 libio = env.Library('io',
             SandeshGenSrcs +
             EventManagerSrc +
@@ -27,6 +32,7 @@ libio = env.Library('io',
              'tcp_server.cc',
              'tcp_session.cc',
              'udp_server.cc',
+             'usock_server',
             ])
 
 env.SConscript('test/SConscript', exports='BuildEnv', duplicate = 0)

--- a/src/io/test/SConscript
+++ b/src/io/test/SConscript
@@ -55,12 +55,19 @@ udp_io_test = env.UnitTest('udp_io_test',
 
 env.Alias('src/io:udp_io_test', udp_io_test)
 
+usock_io_test = env.UnitTest('usock_io_test',
+                             ['usock_io_test.cc'],
+                             )
+
+env.Alias('src/io:usock_io_test', usock_io_test)
+
 # netlink_test = env.Program('netlink_test', ['netlink_test.cc'])
 # env.Alias('src/io:netlink_test', netlink_test)
 
 test_suite = [
     event_manager_test,
     udp_io_test,
+    usock_io_test,
 ]
 
 flaky_test_suite = [

--- a/src/io/test/usock_io_test.cc
+++ b/src/io/test/usock_io_test.cc
@@ -1,0 +1,127 @@
+#include <boost/asio.hpp>
+#include <pthread.h>
+
+#include "testing/gunit.h"
+#include "base/task.h"
+#include "base/test/task_test_util.h"
+#include "io/event_manager.h"
+#include "io/usock_server.h"
+#include "io/test/event_manager_test.h"
+#include "io/io_log.h"
+
+namespace {
+
+class UsockServer: public UnixDomainSocketServer {
+public:
+    UsockServer(boost::asio::io_service & io_service, const char *path)
+      : UnixDomainSocketServer(io_service, path) {
+      set_observer(boost::bind(&UsockServer::EventHandler, this, _1, _2, _3));
+    }
+
+    void EventHandler (UnixDomainSocketServer *server,
+                       UnixDomainSocketSession *session, Event event)
+    {
+        if (event == NEW_SESSION) {
+            LOG(DEBUG, "Session created");
+            char msg[] = "Test Message";
+            session->Send((uint8_t *)msg, sizeof(msg));
+        } else if (event == DELETE_SESSION) {
+            LOG (DEBUG, "Session closed");
+        }
+    }
+};
+
+class UsockClient {
+ public:
+    explicit UsockClient(const std::string &path) :
+        sock_path_(path),
+        socket_(-1) {
+    }
+
+    ~UsockClient() {
+        if (socket_ != -1) {
+            close(socket_);
+        }
+    }
+
+    bool Connect() {
+        socket_ = socket(AF_UNIX, SOCK_STREAM, 0);
+        assert(socket_ != -1);
+        struct sockaddr_un remote;
+        memset(&remote, 0, sizeof(remote));
+        remote.sun_family = AF_UNIX;
+        strncpy(remote.sun_path, sock_path_.c_str(), sizeof(remote.sun_path));
+        int len = strlen(remote.sun_path) + sizeof(remote.sun_family);
+        int res = connect(socket_, (sockaddr *) &remote, len);
+        return (res != -1);
+    }
+
+    int Send(const u_int8_t *data, size_t len) {
+        return send(socket_, data, len, 0);
+    }
+
+    int Recv(u_int8_t *buffer, size_t len) {
+        return recv(socket_, buffer, len, 0);
+    }
+
+    void Close() {
+        int res = shutdown(socket_, SHUT_RDWR);
+        assert(res == 0);
+    }
+
+  private:
+    std::string sock_path_;
+    int socket_;
+};
+
+class UsockTest : public ::testing::Test {
+ protected:
+    UsockTest() :
+        evm_(new EventManager()) {
+    }
+    virtual void SetUp() {
+        snprintf(socket_path_, 512, "/tmp/contrail-iotest-%u.sock", getpid());
+        std::remove(socket_path_);
+        server_.reset(new UsockServer(*evm_->io_service(), socket_path_));
+        thread_.reset(new ServerThread(evm_.get()));
+    }
+
+    virtual void TearDown() {
+        task_util::WaitForIdle();
+        evm_->Shutdown();
+        task_util::WaitForIdle();
+        if (thread_.get() != NULL) {
+            thread_->Join();
+        }
+        task_util::WaitForIdle();
+    }
+
+    std::auto_ptr<ServerThread> thread_;
+    std::auto_ptr<EventManager> evm_;
+    std::auto_ptr<UsockServer> server_;
+    char socket_path_[512];
+};
+
+TEST_F(UsockTest, Basic) {
+    task_util::WaitForIdle();
+    thread_->Start();
+    char path[512];
+    snprintf(path, 512, "/tmp/contrail-iotest-%u.sock", getpid());
+    UsockClient client(path);
+    TASK_UTIL_EXPECT_TRUE(client.Connect());
+    const char exp_msg[] = "Test Message";
+    char rcv_msg[256];
+    int len = client.Recv((u_int8_t *) rcv_msg, sizeof(rcv_msg));
+    TASK_UTIL_EXPECT_EQ(0, memcmp(rcv_msg, exp_msg, len));
+    client.Close();
+    task_util::WaitForIdle();
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    LoggingInit();
+    Sandesh::SetLoggingParams(true, "", SandeshLevel::UT_DEBUG);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/io/usock_server.cc
+++ b/src/io/usock_server.cc
@@ -1,0 +1,174 @@
+/*
+ * The primary method implemented here is Send(), to transmit a
+ * message over the Unix socket. It uses boost::asio::async_write to
+ * send one message at a time over the socket, that is transmitted
+ * asynchronously. The user can repeatedly call Send(). All those
+ * buffers are tail-queued. Upon write_complete callback, the next
+ * message from the front of the queue is sent.
+ */
+#include "usock_server.h"
+
+using boost::asio::buffer_cast;
+using boost::asio::buffer;
+using boost::asio::mutable_buffer;
+
+UnixDomainSocketSession::~UnixDomainSocketSession()
+{
+    if (observer_) {
+        observer_(this, CLOSE);
+    }
+
+    /* Free up any remaining buffers in the queue. */
+    for (BufferQueue::iterator iter = buffer_queue_.begin();
+         iter != buffer_queue_.end(); ++iter) {
+        DeleteBuffer(*iter);
+    }
+    buffer_queue_.clear();
+}
+
+void
+UnixDomainSocketSession::Start()
+{
+    if (observer_) {
+        observer_(this, READY);
+    }
+
+    socket_.async_read_some(boost::asio::buffer(data_),
+                            boost::bind(&UnixDomainSocketSession::
+                                        HandleRead, shared_from_this(),
+                                        boost::asio::placeholders::error,
+                                        boost::asio::placeholders::
+                                        bytes_transferred));
+}
+
+void
+UnixDomainSocketSession::Send(const uint8_t * data, int data_len)
+{
+    if (!data || !data_len) {
+        return;
+    }
+    bool write_now = buffer_queue_.empty();
+    AppendBuffer(data, data_len);
+    if (write_now) {
+        WriteToSocket();
+    }
+}
+
+void
+UnixDomainSocketSession::WriteToSocket()
+{
+    if (buffer_queue_.empty()) {
+        return;
+    }
+
+    boost::asio::mutable_buffer head = buffer_queue_.front();
+    boost::asio::async_write(socket_,
+                             buffer(buffer_cast <const uint8_t *>(head),
+                                    boost::asio::buffer_size(head)),
+                             boost::bind(&UnixDomainSocketSession::
+                                         HandleWrite, shared_from_this(),
+                                         boost::asio::placeholders::error));
+}
+
+void
+UnixDomainSocketSession::AppendBuffer(const uint8_t *src, int bytes)
+{
+    u_int8_t *data = new u_int8_t[bytes];
+    memcpy(data, src, bytes);
+    boost::asio::mutable_buffer buffer =
+        boost::asio::mutable_buffer(data, bytes);
+    buffer_queue_.push_back(buffer);
+}
+
+void
+UnixDomainSocketSession::DeleteBuffer(boost::asio::mutable_buffer buffer)
+{
+    const uint8_t *data = buffer_cast <const uint8_t *>(buffer);
+    delete []data;
+    return;
+}
+
+void
+UnixDomainSocketSession::HandleRead(const boost::system::error_code &error,
+                                    size_t bytes_transferred)
+{
+    if (error) {
+        return;
+    }
+    if (observer_) {
+        observer_(this, READY);
+    }
+}
+
+void
+UnixDomainSocketSession::HandleWrite(const boost::system::error_code &error)
+{
+    /*
+     * async_write() is atomic in that it returns success once the entire message
+     * is sent. If there is an error, it's okay to return from here so that the
+     * session gets closed.
+     */
+    if (error) {
+        return;
+    }
+
+    /*
+     * We are done with the buffer at the head of the queue. Delete it.
+     */
+    DeleteBuffer(buffer_queue_.front());
+    buffer_queue_.pop_front();
+
+    /*
+     * Write the next message, if there.
+     */
+    WriteToSocket();
+
+    /*
+     * Engage on the socket to keep it alive.
+     */
+    socket_.async_read_some(boost::asio::buffer(data_),
+                            boost::bind(&UnixDomainSocketSession::
+                                        HandleRead, shared_from_this(),
+                                        boost::asio::placeholders::error,
+                                        boost::asio::placeholders::
+                                        bytes_transferred));
+}
+
+UnixDomainSocketServer::UnixDomainSocketServer(boost::asio::io_service &io,
+                                               const std::string &file)
+  : io_service_(io),
+    acceptor_(io, boost::asio::local::stream_protocol::endpoint(file)),
+    session_idspace_(0)
+{
+    SessionPtr new_session(new UnixDomainSocketSession(io_service_));
+    acceptor_.async_accept(new_session->socket(),
+                           boost::bind(&UnixDomainSocketServer::
+                                       HandleAccept, this, new_session,
+                                       boost::asio::placeholders::error));
+}
+
+void
+UnixDomainSocketServer::HandleAccept(SessionPtr session,
+                                     const boost::system::error_code &error)
+{
+    UnixDomainSocketSession *socket_session = session.get();
+
+    if (error) {
+        if (observer_) {
+            observer_(this, socket_session, DELETE_SESSION);
+        }
+        return;
+    }
+
+    socket_session->set_session_id(++session_idspace_);
+    if (observer_) {
+        observer_(this, socket_session, NEW_SESSION);
+        session->Start();
+    }
+
+    SessionPtr new_session(new UnixDomainSocketSession(io_service_));
+    acceptor_.async_accept(new_session->socket(),
+                           boost::bind(&UnixDomainSocketServer::
+                                       HandleAccept, this, new_session,
+                                       boost::asio::placeholders::error));
+}

--- a/src/io/usock_server.h
+++ b/src/io/usock_server.h
@@ -1,0 +1,125 @@
+/*
+ * Implement a UNIX domain socket interface using boost::asio.
+ */
+#ifndef _IO_USOCK_SERVER_H_
+#define _IO_USOCK_SERVER_H_
+
+#include <cstdio>
+#include <iostream>
+#include <list>
+#include <boost/array.hpp>
+#include <boost/bind.hpp>
+#include <boost/enable_shared_from_this.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/asio.hpp>
+#include <boost/function.hpp>
+
+#if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+
+class UnixDomainSocketSession :
+public boost::enable_shared_from_this<UnixDomainSocketSession>
+{
+ public:
+    static const int kPDULen = 4096;
+    static const int kPDUHeaderLen = 4;
+    static const int kPDUDataLen = 4092;
+
+    enum Event
+    {
+        EVENT_NONE,
+        READY,
+        CLOSE
+    };
+
+    typedef boost::function <void (UnixDomainSocketSession *, Event)>
+      EventObserver;
+
+    UnixDomainSocketSession (boost::asio::io_service &io_service)
+        : socket_(io_service), session_id_(0)
+    {
+    }
+
+    ~UnixDomainSocketSession();
+
+    boost::asio::local::stream_protocol::socket &socket()
+    {
+        return socket_;
+    }
+
+    void
+    set_observer(EventObserver observer)
+    {
+        observer_ = observer;
+    }
+
+    uint64_t
+    session_id()
+    {
+        return session_id_;
+    }
+
+    void
+    set_session_id(uint64_t id)
+    {
+        session_id_ = id;
+    }
+
+    void Start();
+    void Send(const uint8_t * data, int data_len);
+
+ private:
+    typedef std::list <boost::asio::mutable_buffer> BufferQueue;
+
+    void WriteToSocket();
+    void AppendBuffer(const uint8_t * data, int len);
+    void DeleteBuffer(boost::asio::mutable_buffer);
+    void HandleRead(const boost::system::error_code & error, size_t bytes);
+    void HandleWrite(const boost::system::error_code & error);
+
+    boost::asio::local::stream_protocol::socket socket_;
+    BufferQueue buffer_queue_;
+    uint8_t data_[kPDULen];
+    EventObserver observer_;
+    uint64_t session_id_;
+};
+
+typedef boost::shared_ptr <UnixDomainSocketSession> SessionPtr;
+
+class UnixDomainSocketServer
+{
+ public:
+
+    enum Event
+    {
+        EVENT_NONE,
+        NEW_SESSION,
+        DELETE_SESSION
+    };
+
+    typedef boost::function <void (UnixDomainSocketServer *,
+                                   UnixDomainSocketSession *, Event) >
+      EventObserver;
+
+    UnixDomainSocketServer(boost::asio::io_service &io_service,
+                           const std::string &file);
+
+    void HandleAccept(SessionPtr new_session,
+                      const boost::system::error_code &error);
+
+    void set_observer(EventObserver observer)
+    {
+        observer_ = observer;
+    }
+
+ private:
+    boost::asio::io_service &io_service_;
+    EventObserver observer_;
+    boost::asio::local::stream_protocol::acceptor acceptor_;
+    uint64_t session_idspace_;
+};
+
+#else // defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+#error Local sockets not available on this platform.
+#endif // defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
+
+#endif

--- a/src/vnsw/agent/SConscript
+++ b/src/vnsw/agent/SConscript
@@ -42,6 +42,7 @@ cpppath = [
     'vnsw/agent/uve',
     'vnsw/agent/openstack',
     'vrouter/sandesh',
+    'vnsw/agent/nexthop_server',
 ]
 
 if sys.platform.startswith('linux'):
@@ -92,6 +93,7 @@ env.Append(LIBPATH = MapBuildDir([
     'xml',
     'xmpp',
     'third_party/bind-9.9.2-P1/lib/isc',
+    'vnsw/agent/nexthop_server',
 ]))
 
 ##########################################################################
@@ -147,6 +149,7 @@ env.Prepend(LIBS = [
     'nova_ins_thrift',
     'uve',
     'vgw',
+    'vnswnhserver',
 ])
 
 ##########################################################################
@@ -155,7 +158,7 @@ env.Prepend(LIBS = [
 AGENT_MULTIPATH_LIBS = [
     'cpuinfo',
     'vnswoperdb',
-    'vnswcmn'
+    'vnswcmn',
 ]
 
 # Set LIBS environment to ensure libraries are built
@@ -302,6 +305,7 @@ subdirs = [
     'uve',
     'vgw',
     'vrouter',
+    'nexthop_server',
 ]
 
 for dir in subdirs:

--- a/src/vnsw/agent/cmn/agent_factory.cc
+++ b/src/vnsw/agent/cmn/agent_factory.cc
@@ -10,9 +10,13 @@ AgentObjectFactory *Factory<AgentObjectFactory>::singleton_ = NULL;
 #include "cmn/agent_signal.h"
 #include "oper/ifmap_dependency_manager.h"
 #include "oper/instance_manager.h"
+#include "nexthop_server/nexthop_manager.h"
+
 FACTORY_STATIC_REGISTER(AgentObjectFactory, AgentSignal,
                         AgentSignal);
 FACTORY_STATIC_REGISTER(AgentObjectFactory, IFMapDependencyManager,
                         IFMapDependencyManager);
 FACTORY_STATIC_REGISTER(AgentObjectFactory, InstanceManager, InstanceManager);
+FACTORY_STATIC_REGISTER(AgentObjectFactory, NexthopManager,
+                        NexthopManager);
 

--- a/src/vnsw/agent/cmn/agent_factory.h
+++ b/src/vnsw/agent/cmn/agent_factory.h
@@ -17,6 +17,7 @@ class DBGraph;
 class IFMapDependencyManager;
 class InstanceManager;
 class FlowTable;
+class NexthopManager;
 
 class AgentObjectFactory : public Factory<AgentObjectFactory> {
     FACTORY_TYPE_N1(AgentObjectFactory, KSync, Agent *);
@@ -27,6 +28,8 @@ class AgentObjectFactory : public Factory<AgentObjectFactory> {
                     DBGraph *);
     FACTORY_TYPE_N1(AgentObjectFactory, InstanceManager,
                     Agent *);
+    FACTORY_TYPE_N2(AgentObjectFactory, NexthopManager, EventManager *,
+                    const std::string&);
 };
 
 #endif // vnsw_agent_factory_hpp

--- a/src/vnsw/agent/init/agent_param.cc
+++ b/src/vnsw/agent/init/agent_param.cc
@@ -484,6 +484,18 @@ void AgentParam::ParseServiceInstance() {
 
 }
 
+void AgentParam::ParseNexthopServer() {
+    GetValueFromTree<string>(nexthop_server_endpoint_,
+                             "NEXTHOP-SERVER.endpoint");
+    GetValueFromTree<bool>(nexthop_server_add_pid_,
+                           "NEXTHOP-SERVER.add_pid");
+    if (nexthop_server_add_pid_) {
+        std::stringstream ss;
+        ss << nexthop_server_endpoint_ << "." << getpid();
+        nexthop_server_endpoint_ = ss.str();
+    }
+}
+
 void AgentParam::ParseCollectorArguments
     (const boost::program_options::variables_map &var_map) {
     GetOptValue< vector<string> >(var_map, collector_server_list_,
@@ -636,6 +648,20 @@ void AgentParam::ParseServiceInstanceArguments
 
 }
 
+void AgentParam::ParseNexthopServerArguments
+    (const boost::program_options::variables_map &var_map) {
+    GetOptValue<string>(var_map, nexthop_server_endpoint_,
+                        "NEXTHOP-SERVER.endpoint");
+    GetOptValue<bool>(var_map, nexthop_server_add_pid_,
+                             "NEXTHOP-SERVER.add_pid");
+    if (nexthop_server_add_pid_) {
+        std::stringstream ss;
+        ss << nexthop_server_endpoint_ << "." << getpid();
+        nexthop_server_endpoint_ = ss.str();
+    }
+}
+
+
 // Initialize hypervisor mode based on system information
 // If "/proc/xen" exists it means we are running in Xen dom0
 void AgentParam::InitFromSystem() {
@@ -681,6 +707,8 @@ void AgentParam::InitFromConfig() {
     ParseSimulateEvpnTor();
     ParseServiceInstance();
     ParseAgentMode();
+    ParseNexthopServer();
+
     cout << "Config file <" << config_file_ << "> parsing completed.\n";
     return;
 }
@@ -701,6 +729,8 @@ void AgentParam::InitFromArguments() {
     ParseDhcpRelayModeArguments(var_map_);
     ParseServiceInstanceArguments(var_map_);
     ParseAgentModeArguments(var_map_);
+    ParseNexthopServerArguments(var_map_);
+
     return;
 }
 
@@ -924,6 +954,7 @@ void AgentParam::LogConfig() const {
     LOG(DEBUG, "Vmware mode                 : Esxi_Neutron");
     }
     }
+    LOG(DEBUG, "Nexthop server endpoint  : " << nexthop_server_endpoint_);
 }
 
 void AgentParam::PostValidateLogConfig() const {
@@ -977,7 +1008,7 @@ AgentParam::AgentParam(Agent *agent, bool enable_flow_options,
         simulate_evpn_tor_(false), si_netns_command_(),
         si_docker_command_(), si_netns_workers_(0),
         si_netns_timeout_(0), si_haproxy_ssl_cert_path_(),
-        vmware_mode_(ESXI_NEUTRON) {
+        vmware_mode_(ESXI_NEUTRON), nexthop_server_endpoint_() {
 
     vgw_config_table_ = std::auto_ptr<VirtualGatewayConfigTable>
         (new VirtualGatewayConfigTable(agent));

--- a/src/vnsw/agent/init/agent_param.h
+++ b/src/vnsw/agent/init/agent_param.h
@@ -113,6 +113,9 @@ public:
         return si_haproxy_ssl_cert_path_;
     }
 
+    std::string nexthop_server_endpoint() const {
+        return nexthop_server_endpoint_;
+    }
 
     const std::string &config_file() const { return config_file_; }
     const std::string &program_name() const { return program_name_;}
@@ -249,6 +252,8 @@ private:
     void ParseSimulateEvpnTor();
     void ParseServiceInstance();
     void ParseAgentMode();
+    void ParseNexthopServer();
+
     void set_agent_mode(const std::string &mode);
 
     void ParseCollectorArguments
@@ -274,6 +279,8 @@ private:
     void ParseServiceInstanceArguments
         (const boost::program_options::variables_map &v);
     void ParseAgentModeArguments
+        (const boost::program_options::variables_map &v);
+    void ParseNexthopServerArguments
         (const boost::program_options::variables_map &v);
 
     boost::program_options::variables_map var_map_;
@@ -345,6 +352,8 @@ private:
     VmwareMode vmware_mode_;
     // List of IP addresses on the compute node.
     AddressList compute_node_address_list_;
+    std::string nexthop_server_endpoint_;
+    bool nexthop_server_add_pid_;
 
     DISALLOW_COPY_AND_ASSIGN(AgentParam);
 };

--- a/src/vnsw/agent/nexthop_server/SConscript
+++ b/src/vnsw/agent/nexthop_server/SConscript
@@ -1,0 +1,13 @@
+# -*- mode: python; -*-
+
+import sys
+Import('AgentEnv')
+env = AgentEnv.Clone()
+env.CppEnableExceptions()
+
+vnswnhserver_sources = ['nexthop_client.cc', 'nexthop_server.cc',
+                        'nexthop_manager.cc']
+
+vnswnhserver = env.Library('vnswnhserver', vnswnhserver_sources)
+
+env.SConscript('test/SConscript', exports='AgentEnv', duplicate = 0)

--- a/src/vnsw/agent/nexthop_server/nexthop_client.cc
+++ b/src/vnsw/agent/nexthop_server/nexthop_client.cc
@@ -1,0 +1,151 @@
+/*
+ * Each object of NexthopDBClient class interacts with the master
+ * instance of NexthopDBServer and to the underlying (Unix socket) session
+ * connected to the client process:
+ *
+ *                {RemoveNexthop()}
+ *                {AddNexthop()}             {Send()}
+ * [NexthopDBServer] ------ [NexthopDBClient] ----- [UnixDomainSocketSession]
+ *                     1:n                     1:1
+ */
+#include <base/logging.h>
+#include "nexthop_server/nexthop_server.h"
+#include <pthread.h>
+#include "rapidjson/document.h"
+#include "rapidjson/filestream.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+NexthopDBClient::NexthopDBClient(UnixDomainSocketSession *session,
+                                 NexthopDBServer *server)
+  :  nexthop_list_()
+{
+    server_ = server;
+    session_ = session;
+    session_->set_observer(boost::bind(&NexthopDBClient::EventHandler, this,
+                                       _1, _2));
+}
+
+NexthopDBClient::~NexthopDBClient()
+{
+    for (NexthopListIterator iter = nexthop_list_.begin();
+         iter != nexthop_list_.end(); ++iter) {
+        nexthop_list_.erase (iter);
+    }
+}
+
+void
+NexthopDBClient::EventHandler(UnixDomainSocketSession *session,
+                              UnixDomainSocketSession::Event event)
+{
+    if (event == UnixDomainSocketSession::READY) {
+        WriteMessage();
+    } else if (event == UnixDomainSocketSession::CLOSE) {
+        LOG (DEBUG, "[NexthopServer] Client " << session->session_id() <<
+             " closed session");
+        server_->RemoveClient(session->session_id());
+    }
+}
+
+void
+NexthopDBClient::AddNexthop(NexthopDBEntry::NexthopPtr nh)
+{
+    nexthop_list_.push_back(nh);
+}
+
+void
+NexthopDBClient::RemoveNexthop(NexthopDBEntry::NexthopPtr nh)
+{
+    for (NexthopListIterator iter = nexthop_list_.begin();
+         iter != nexthop_list_.end(); ++iter) {
+        if (*(*iter) == *nh) {
+            iter = nexthop_list_.erase(iter);
+            break;
+        }
+    }
+}
+
+bool
+NexthopDBClient::FindNexthop(NexthopDBEntry::NexthopPtr nh)
+{
+    for (NexthopListIterator iter = nexthop_list_.begin();
+         iter != nexthop_list_.end(); ++iter) {
+        if (*(*iter) == *nh) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Caller should free the returned buffer */
+uint8_t *
+NexthopDBClient::NextMessage(int *data_len)
+{
+    rapidjson::StringBuffer s;
+    rapidjson::Writer <rapidjson::StringBuffer> writer(s);
+
+    writer.StartObject();
+
+    int pdu_len = 0;
+
+    for (NexthopListIterator iter = nexthop_list_.begin();
+         iter != nexthop_list_.end();) {
+        NexthopDBEntry::NexthopPtr tnh = *iter;
+
+        if ((pdu_len + tnh->EncodedLength()) >
+            UnixDomainSocketSession::kPDUDataLen) {
+            break;
+        }
+
+        writer.String((tnh->nexthop_string()).c_str());
+        writer.StartObject();
+        const char *action = (tnh->state() ==
+             NexthopDBEntry::NEXTHOP_STATE_DELETED) ? "del" : "add";
+        writer.String("action");
+        writer.String(action);
+        writer.EndObject();
+
+        pdu_len += tnh->EncodedLength();
+
+        iter = nexthop_list_.erase(iter);
+    }
+
+    writer.EndObject();
+
+    /* Nothing to consume? */
+    if (!pdu_len) {
+        return NULL;
+    }
+
+    const char *nhdata = s.GetString();
+    int nhlen = s.Size();
+    u_int8_t *out_data = new u_int8_t[nhlen + 4];
+    out_data[0] = (unsigned char) (nhlen >> 24);
+    out_data[1] = (unsigned char) (nhlen >> 16);
+    out_data[2] = (unsigned char) (nhlen >> 8);
+    out_data[3] = (unsigned char) nhlen;
+    memcpy(&out_data[4], nhdata, nhlen);
+    *data_len = nhlen + 4;
+    return out_data;
+}
+
+void
+NexthopDBClient::WriteMessage()
+{
+    uint8_t *data = NULL;
+    int data_len;
+
+    while(1) {
+        data_len = 0;
+        data = NextMessage(&data_len);
+        if (!data || !data_len) {
+            break;
+        }
+
+        /*
+         * Send always succeeds
+         */
+        session_->Send(data, data_len);
+        free(data);
+    }
+}

--- a/src/vnsw/agent/nexthop_server/nexthop_client.h
+++ b/src/vnsw/agent/nexthop_server/nexthop_client.h
@@ -1,0 +1,66 @@
+/*
+ * NexthopDBClient class: represents a client connecting to the nexthop-server
+ *                        interface for nexthop notifications.
+ */
+#ifndef _AGENT_NHS_NEXTHOP_CLIENT_H_
+#define _AGENT_NHS_NEXTHOP_CLIENT_H_
+
+#include <boost/array.hpp>
+#include <boost/asio.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/bind.hpp>
+#include <boost/enable_shared_from_this.hpp>
+#include <boost/shared_ptr.hpp>
+#include <cstdio>
+#include <iostream>
+#include "io/usock_server.h"
+#include "nexthop_entry.h"
+#include <tbb/mutex.h>
+
+class NexthopDBServer;
+
+/*
+ * Class to represent each client that connects to nexthop-server to
+ * receive nexthop notifications.
+ */
+class NexthopDBClient
+{
+ public:
+
+    typedef boost::shared_ptr <NexthopDBClient> ClientPtr;
+    typedef std::vector <NexthopDBEntry::NexthopPtr> NexthopList;
+    typedef std::vector <NexthopDBEntry::NexthopPtr>::iterator
+        NexthopListIterator;
+
+    NexthopDBClient(UnixDomainSocketSession *session, NexthopDBServer *server);
+    ~NexthopDBClient();
+
+    void AddNexthop(NexthopDBEntry::NexthopPtr nh);
+    void RemoveNexthop(NexthopDBEntry::NexthopPtr nh);
+    bool FindNexthop(NexthopDBEntry::NexthopPtr nh);
+
+    /*
+     * Handle events from the underlying (unix socket) session to this client
+     */
+    void EventHandler(UnixDomainSocketSession *,
+                      UnixDomainSocketSession::Event);
+
+ protected:
+    friend class NexthopDBServer;
+
+ private:
+    UnixDomainSocketSession *session_;
+    NexthopDBServer *server_;
+
+    /*
+     * Each client object maintains its own vector of nexthops that need to be
+     * dispatched. The nexthop pointer is removed from the vector after the
+     * dispatch.
+     */
+    NexthopList nexthop_list_;
+
+    void WriteMessage();
+    uint8_t *NextMessage(int *length);
+};
+
+#endif

--- a/src/vnsw/agent/nexthop_server/nexthop_entry.h
+++ b/src/vnsw/agent/nexthop_server/nexthop_entry.h
@@ -1,0 +1,65 @@
+/*
+ * A simple representation of a nexthop entry: the nexthop string and
+ * its current state in the Nexthop DB. Used to send nexthop notifications
+ * to registered clients.
+ */
+#ifndef _AGENT_NHS_NEXTHOP_ENTRY_H_
+#define _AGENT_NHS_NEXTHOP_ENTRY_H_
+
+#include <boost/array.hpp>
+#include <boost/asio.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/bind.hpp>
+#include <boost/enable_shared_from_this.hpp>
+#include <boost/shared_ptr.hpp>
+#include <cstdio>
+#include <iostream>
+#include <tbb/mutex.h>
+
+class NexthopDBEntry {
+
+    static const int kNexthopEntryOverhead = 32;
+
+ public:
+
+    typedef boost::shared_ptr<NexthopDBEntry> NexthopPtr;
+
+    enum NexthopDBEntryState {
+        NEXTHOP_STATE_CLEAN,
+        NEXTHOP_STATE_MARKED,
+        NEXTHOP_STATE_DELETED
+    };
+
+    NexthopDBEntry(const std::string& nh)
+      : nexthop_string_(nh) {}
+
+    ~NexthopDBEntry() {
+    }
+
+    int EncodedLength() {
+        return (nexthop_string_.length() + kNexthopEntryOverhead);
+    }
+
+    void set_state (NexthopDBEntryState state) {
+        state_ = state;
+    }
+
+    NexthopDBEntryState state() {
+        return state_;
+    }
+
+    std::string& nexthop_string() {
+        return nexthop_string_;
+    }
+
+    bool operator== (NexthopDBEntry& other)
+    {
+        return (nexthop_string_ == other.nexthop_string());
+    }
+
+ private:
+    std::string nexthop_string_;
+    NexthopDBEntryState state_;
+};
+
+#endif

--- a/src/vnsw/agent/nexthop_server/nexthop_manager.cc
+++ b/src/vnsw/agent/nexthop_server/nexthop_manager.cc
@@ -1,0 +1,54 @@
+/*
+ * Implementation of NexthopManager class. It does the following:
+ *   - instantiates NexthopServer object so that interested clients can
+ *      register for nexthop notification.
+ *   - registers with the vrouter-agent nexthopDB for "db.nexthop.0"
+ *      table to get nexthop updates. The nexthops are actually stored
+ *      in the NexthopServer object.
+ */
+#include "db/db.h"
+#include "cmn/agent_signal.h"
+#include "io/event_manager.h"
+#include "nexthop_manager.h"
+#include "oper/tunnel_nh.h"
+#include <sys/wait.h>
+
+NexthopManager::NexthopManager(EventManager *evm, const std::string &endpoint)
+  : evm_(evm), nh_table_(NULL), nh_listener_(DBTableBase::kInvalidId),
+    nh_server_(new NexthopDBServer(*(evm->io_service()), endpoint))
+{
+}
+
+NexthopManager::~NexthopManager()
+{
+}
+
+void
+NexthopManager::Initialize(DB *database)
+{
+    nh_table_ = database->FindTable("db.nexthop.0");
+    assert(nh_table_);
+    nh_listener_ =
+      nh_table_->Register(boost::bind(&NexthopManager::EventObserver, this,
+                                      _1, _2));
+}
+
+void
+NexthopManager::Terminate()
+{
+    nh_table_->Unregister(nh_listener_);
+}
+
+void
+NexthopManager::EventObserver(DBTablePartBase *db_part, DBEntryBase *entry)
+{
+    NextHop *nh = static_cast <NextHop *>(entry);
+    if (nh->GetType () == NextHop::TUNNEL) {
+        TunnelNH *tnh = (TunnelNH *) nh;
+        if (nh->IsDeleted()) {
+            nh_server_->FindAndRemoveNexthop(tnh->GetDip()->to_string());
+        } else {
+            nh_server_->FindOrCreateNexthop(tnh->GetDip()->to_string());
+        }
+    }
+}

--- a/src/vnsw/agent/nexthop_server/nexthop_manager.h
+++ b/src/vnsw/agent/nexthop_server/nexthop_manager.h
@@ -1,0 +1,80 @@
+/*
+ * A generic server interface to send notification about tunnel nexthops
+ * to interested clients. The server supports any number of clients. The
+ * communication occurs over a UNIX socket. The message is really a JSON
+ * frame:
+ *
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                             Length                            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                                                               |
+       |                       JSON text (variable)                    |
+       |                                                               |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *
+ * where the JSON text follows the format:
+ *
+ *    {
+ *      "<next hop 1 IP address>": {
+ *          "action": <operation>
+ *      },
+ *      "<next hop 2 IP address>": {
+ *          "action": <operation>
+ *      },
+ *      ...
+ *    }
+ *
+ * <operation> can take one of the two values: "add" or "del", indicating
+ * whether the next hop has been added or deleted.
+ *
+ * One can test a sample client by running:
+ *     sudo socat -s - UNIX-CONNECT:/var/run/contrail-nhserv.socket
+ */
+#ifndef __AGENT_NHS_NEXTHOP_MANAGER_H__
+#define __AGENT_NHS_NEXTHOP_MANAGER_H__
+
+#include "base/queue_task.h"
+#include <boost/asio.hpp>
+#include "cmn/agent_signal.h"
+#include "db/db_entry.h"
+#include "db/db_table.h"
+#include "nexthop_server.h"
+#include "oper/nexthop.h"
+#include <queue>
+
+class DB;
+class EventManager;
+
+/*
+ * Register for nexthop events from the global nexthop table.
+ * Receive nexthop notifications from the nexthop table and send to
+ * registered clients.
+ */
+class NexthopManager
+{
+ public:
+
+    NexthopManager(EventManager *evm, const std::string &endpoint);
+    ~NexthopManager();
+
+    void Initialize(DB *database);
+    void Terminate();
+
+ private:
+
+    /*
+     * Event observer for changes in the "db.nexthop.0" table.
+     */
+    void EventObserver(DBTablePartBase * db_part, DBEntryBase * entry);
+
+    EventManager *evm_;
+    DBTableBase *nh_table_;
+    DBTableBase::ListenerId nh_listener_;
+    boost::scoped_ptr<NexthopDBServer> nh_server_;
+
+    DISALLOW_COPY_AND_ASSIGN(NexthopManager);
+};
+
+#endif

--- a/src/vnsw/agent/nexthop_server/nexthop_server.cc
+++ b/src/vnsw/agent/nexthop_server/nexthop_server.cc
@@ -1,0 +1,143 @@
+/*
+ * NexthopDBServer maintains two primary data structures:
+ * (1) nexthop_table: a std::map DB of nexthop entries (NexthopDBEntry)
+ *     keyed through a string representation of the nexthop address.
+ * (2) client_table: a std::map DB of client entries (NexthopDBClient)
+ *     keyed through the session_id of the underlying session
+ *     (UnixDomainSocketSession).
+ */
+#include <base/logging.h>
+#include "nexthop_client.h"
+#include "nexthop_server.h"
+#include <pthread.h>
+#include "rapidjson/document.h"
+#include "rapidjson/filestream.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+NexthopDBServer::NexthopDBServer(boost::asio::io_service &io,
+                                 const std::string &path)
+  : io_service_(io), endpoint_path_(path), nexthop_table_(), client_table_()
+{
+    std::remove(endpoint_path_.c_str());
+    io_server_.reset(new UnixDomainSocketServer(io_service_, endpoint_path_));
+    io_server_->set_observer(boost::bind(&NexthopDBServer::EventHandler, this,
+                                         _1, _2, _3));
+}
+
+void
+NexthopDBServer::Run()
+{
+    io_service_.run();
+}
+
+void
+NexthopDBServer::EventHandler(UnixDomainSocketServer * server,
+                              UnixDomainSocketSession * session,
+                              UnixDomainSocketServer::Event event)
+{
+    tbb::mutex::scoped_lock lock(mutex_);
+    if (event == UnixDomainSocketServer::NEW_SESSION) {
+        NexthopDBClient::ClientPtr cl(new NexthopDBClient(session, this));
+        AddClient(cl);
+    } else if (event == UnixDomainSocketServer::DELETE_SESSION) {
+        NexthopDBClient::ClientPtr cl = client_table_[session->session_id()];
+        if (cl) {
+            RemoveClient(session->session_id());
+        }
+    }
+}
+
+void
+NexthopDBServer::AddClient(NexthopDBClient::ClientPtr cl)
+{
+    /* Add client to the client table */
+    assert (client_table_[cl->session_->session_id()] == NULL);
+    client_table_[cl->session_->session_id()] = cl;
+
+    /* Build the client's nexthop list */
+    for (NexthopIterator iter = nexthop_table_.begin();
+         iter != nexthop_table_.end(); ++iter) {
+        if (iter->second) {
+            cl->AddNexthop(iter->second);
+        }
+    }
+
+    cl->WriteMessage();
+    LOG (DEBUG, "[NexthopServer] New client: " << cl->session_->session_id());
+}
+
+void
+NexthopDBServer::RemoveClient(uint64_t session_id)
+{
+    LOG (DEBUG, "[NexthopServer] Remove client " << session_id);
+    client_table_.erase(session_id);
+}
+
+void
+NexthopDBServer::TriggerClients()
+{
+    for (ClientIterator iter = client_table_.begin();
+         iter != client_table_.end(); ++iter) {
+        iter->second->WriteMessage();
+    }
+}
+
+void
+NexthopDBServer::AddNexthop(NexthopDBEntry::NexthopPtr nh)
+{
+    for (ClientIterator iter = client_table_.begin();
+         iter != client_table_.end(); ++iter) {
+        iter->second->AddNexthop(nh);
+    }
+}
+
+NexthopDBEntry::NexthopPtr
+NexthopDBServer::FindOrCreateNexthop(const std::string &nh_str)
+{
+    tbb::mutex::scoped_lock lock (mutex_);
+
+    /*
+     * Does the nexthop exist? If so, return.
+     */
+    if (nexthop_table_[nh_str] != NULL) {
+        return nexthop_table_[nh_str];
+    }
+
+    NexthopDBEntry::NexthopPtr nh(new NexthopDBEntry(nh_str));
+    nexthop_table_[nh_str] = nh;
+
+    /*
+     * Add the nexthop to the tail of each client's announce list and trigger
+     * clients so they are notified of the new nexthop.
+     */
+    AddNexthop(nh);
+    TriggerClients();
+    return nh;
+}
+
+void
+NexthopDBServer::FindAndRemoveNexthop(const std::string &str)
+{
+    tbb::mutex::scoped_lock lock(mutex_);
+
+    if (nexthop_table_[str] == NULL) {
+        return;
+    }
+    NexthopDBEntry::NexthopPtr nh = nexthop_table_[str];
+    RemoveNexthop(nh);
+    nexthop_table_.erase(str);
+    TriggerClients();
+}
+
+void
+NexthopDBServer::RemoveNexthop(NexthopDBEntry::NexthopPtr nh)
+{
+    nh->set_state(NexthopDBEntry::NEXTHOP_STATE_DELETED);
+    for (ClientIterator iter = client_table_.begin();
+         iter != client_table_.end(); ++iter) {
+        if (!iter->second->FindNexthop(nh)) {
+            iter->second->AddNexthop(nh);
+        }
+    }
+}

--- a/src/vnsw/agent/nexthop_server/nexthop_server.h
+++ b/src/vnsw/agent/nexthop_server/nexthop_server.h
@@ -1,0 +1,59 @@
+/*
+ * NexthopDBServer class: represents the master server interface that
+ *                        has a Nexthop DB store and a list of clients.
+ */
+#ifndef _AGENT_NHS_NEXTHOP_SERVER_H_
+#define _AGENT_NHS_NEXTHOP_SERVER_H_
+
+#include <boost/array.hpp>
+#include <boost/asio.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/bind.hpp>
+#include <boost/enable_shared_from_this.hpp>
+#include <boost/scoped_ptr.hpp>
+#include <boost/shared_ptr.hpp>
+#include <cstdio>
+#include <iostream>
+#include "io/usock_server.h"
+#include "nexthop_client.h"
+#include "nexthop_entry.h"
+#include <tbb/mutex.h>
+
+/*
+ * The main server object for serving nexthops to connected clients.
+ */
+class NexthopDBServer
+{
+  public:
+
+    typedef std::map <uint64_t, NexthopDBClient::ClientPtr> ClientDB;
+    typedef std::map <uint64_t, NexthopDBClient::ClientPtr>::iterator
+      ClientIterator;
+    typedef std::map <std::string, NexthopDBEntry::NexthopPtr> NexthopDB;
+    typedef std::map <std::string, NexthopDBEntry::NexthopPtr>::iterator
+        NexthopIterator;
+
+    NexthopDBServer(boost::asio::io_service &io, const std::string &path);
+
+    NexthopDBEntry::NexthopPtr FindOrCreateNexthop(const std::string &str);
+    void FindAndRemoveNexthop(const std::string &str);
+    void Run();
+    void EventHandler(UnixDomainSocketServer *, UnixDomainSocketSession *,
+                      UnixDomainSocketServer::Event);
+    void RemoveClient(uint64_t);
+
+  private:
+    void AddClient(NexthopDBClient::ClientPtr cl);
+    void TriggerClients();
+    void AddNexthop(NexthopDBEntry::NexthopPtr nh);
+    void RemoveNexthop(NexthopDBEntry::NexthopPtr nh);
+
+    boost::asio::io_service &io_service_;
+    std::string endpoint_path_;
+    boost::scoped_ptr<UnixDomainSocketServer> io_server_;
+    NexthopDB nexthop_table_;
+    ClientDB client_table_;
+    tbb::mutex mutex_;
+};
+
+#endif

--- a/src/vnsw/agent/nexthop_server/test/SConscript
+++ b/src/vnsw/agent/nexthop_server/test/SConscript
@@ -1,0 +1,15 @@
+# -*- mode: python; -*-
+import re
+Import('AgentEnv')
+env = AgentEnv.Clone()
+
+AgentEnv.MakeTestEnv(env)
+
+init_test_suite = []
+test_agent_init = AgentEnv.MakeTestCmd(env, 'test_agent_init', init_test_suite)
+
+test = env.TestSuite('agent-nhs-test', init_test_suite)
+env.Alias('agent:nhs', test)
+env.Alias('controller/src/vnsw/agent/nexthop_server:test', test)
+
+Return('init_test_suite')

--- a/src/vnsw/agent/nexthop_server/test/test_agent_init.cc
+++ b/src/vnsw/agent/nexthop_server/test/test_agent_init.cc
@@ -1,0 +1,233 @@
+#include "base/os.h"
+#include <base/task.h>
+#include <base/util.h>
+#include <cfg/cfg_init.h>
+#include <cfg/cfg_interface.h>
+#include <cmn/agent_cmn.h>
+#include <io/event_manager.h>
+#include <oper/interface_common.h>
+#include <oper/operdb_init.h>
+#include <oper/vm.h>
+#include <oper/nexthop.h>
+#include <oper/tunnel_nh.h>
+#include <oper/mirror_table.h>
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/document.h"
+#include "rapidjson/reader.h"
+#include <test/test_cmn_util.h>
+#include "testing/gunit.h"
+#include "vr_types.h"
+#include <vrouter/ksync/ksync_init.h>
+
+using namespace std;
+using namespace boost::assign;
+
+#define VNSW_NEXTHOP_SERVER_CONFIG_FILE \
+    "controller/src/vnsw/agent/nexthop_server/test/vnswa_cfg.ini"
+
+class CfgTest : public ::testing::Test {
+public:
+
+    ~CfgTest() {
+        TestAgentInit *init = client_->agent_init();
+        init->Shutdown();
+        AsioStop();
+    }
+
+    void SetUp() {
+    }
+
+    void TearDown() {
+        WAIT_FOR(1000, 1000, agent_->vrf_table()->Size() == 1);
+    }
+
+    void WaitForIdle(uint32_t size, uint32_t max_retries) {
+        do {
+            client_->WaitForIdle();
+        } while ((agent_->nexthop_table()->Size() == size) &&
+                 max_retries-- > 0);
+    }
+
+    void CreateTunnelNH(const string &vrf_name, const Ip4Address &sip,
+                        const Ip4Address &dip, bool policy,
+                        TunnelType::TypeBmap bmap) {
+        DBRequest req;
+        TunnelNHData *data = new TunnelNHData();
+        uint32_t table_size = agent_->nexthop_table()->Size();
+
+        NextHopKey *key = new TunnelNHKey(vrf_name, sip, dip, policy,
+                                          TunnelType::ComputeType(bmap));
+        req.oper = DBRequest::DB_ENTRY_ADD_CHANGE;
+        req.key.reset(key);
+        req.data.reset(data);
+        agent_->nexthop_table()->Enqueue(&req);
+        WaitForIdle(table_size, 5);
+    }
+
+    void DeleteTunnelNH(const string &vrf_name, const Ip4Address &sip,
+                        const Ip4Address &dip, bool policy,
+                        TunnelType::TypeBmap bmap) {
+        DBRequest req;
+        TunnelNHData *data = new TunnelNHData();
+        uint32_t table_size = agent_->nexthop_table()->Size();
+
+        NextHopKey *key = new TunnelNHKey(vrf_name, sip, dip, policy,
+                                          TunnelType::ComputeType(bmap));
+        req.oper = DBRequest::DB_ENTRY_DELETE;
+        req.key.reset(key);
+        req.data.reset(data);
+        agent_->nexthop_table()->Enqueue(&req);
+        WaitForIdle(table_size, 5);
+    }
+
+    Agent *agent_;
+    std::auto_ptr<TestClient> client_;
+};
+
+static void
+ValidateRcvdMessage(const u_int8_t *rcv_msg, int rcv_len, int exp_len,
+                    const char *exp_ip, const char *exp_action)
+{
+    char rcv_json[256];
+
+    TASK_UTIL_EXPECT_EQ(exp_len, rcv_len);
+    int msg_len = rcv_msg[0] << 24 | rcv_msg[1] << 16 | rcv_msg[2] << 8 | rcv_msg[3];
+    TASK_UTIL_EXPECT_EQ((exp_len - 4), msg_len);
+    memcpy(rcv_json, &rcv_msg[4], msg_len);
+    rapidjson::Document d;
+    d.Parse<0>((const char *)rcv_json);
+    TASK_UTIL_EXPECT_TRUE(d.IsObject());
+    TASK_UTIL_EXPECT_TRUE(d.HasMember(exp_ip));
+    TASK_UTIL_EXPECT_TRUE(d[exp_ip].HasMember("action"));
+    TASK_UTIL_EXPECT_EQ(0, strcmp(exp_action,
+                                  d[exp_ip]["action"].GetString()));
+}
+
+class NexthopClient {
+ public:
+    explicit NexthopClient(const std::string &path) :
+        sock_path_(path),
+        socket_(-1) {
+    }
+
+    ~NexthopClient() {
+        if (socket_ != -1) {
+            close(socket_);
+        }
+    }
+
+    bool Connect() {
+        socket_ = socket(AF_UNIX, SOCK_STREAM, 0);
+        assert(socket_ != -1);
+        struct sockaddr_un remote;
+        memset(&remote, 0, sizeof(remote));
+        remote.sun_family = AF_UNIX;
+        strncpy(remote.sun_path, sock_path_.c_str(), sizeof(remote.sun_path));
+        int len = strlen(remote.sun_path) + sizeof(remote.sun_family);
+        int res = connect(socket_, (sockaddr *) &remote, len);
+        return (res != -1);
+    }
+
+    int Send(const u_int8_t *data, size_t len) {
+        return send(socket_, data, len, 0);
+    }
+
+    int Recv(u_int8_t *buffer, size_t len) {
+        return recv(socket_, buffer, len, 0);
+    }
+
+    void Close() {
+        int res = shutdown(socket_, SHUT_RDWR);
+        assert(res == 0);
+    }
+
+  private:
+    std::string sock_path_;
+    int socket_;
+};
+
+TEST_F(CfgTest, TunnelNH) {
+    client_.reset(TestInit(VNSW_NEXTHOP_SERVER_CONFIG_FILE, false));
+    agent_ = client_->agent();
+    AddEncapList(agent_, "MPLSoUDP", "MPLSoGRE", NULL);
+
+    client_->WaitForIdle();
+
+    if (!agent_->params() ||
+        !agent_->params()->nexthop_server_endpoint().length()) {
+        LOG(ERROR, "nexthop server endpoint not specified");
+        FAIL();
+    }
+
+    NexthopClient uclient(agent_->params()->nexthop_server_endpoint());
+    TASK_UTIL_EXPECT_TRUE(uclient.Connect());
+
+    CreateTunnelNH(agent_->fabric_vrf_name(), agent_->router_id(),
+                   Ip4Address::from_string("10.1.1.10"), false,
+                   ((1 << TunnelType::MPLS_GRE) | (1 << TunnelType::MPLS_UDP)));
+
+    u_int8_t rcv_msg[256];
+    int len;
+
+    len = uclient.Recv(rcv_msg, sizeof(rcv_msg));
+    ValidateRcvdMessage(rcv_msg, len, 34, "10.1.1.10", "add");
+
+    CreateTunnelNH(agent_->fabric_vrf_name(), agent_->router_id(),
+                   Ip4Address::from_string("10.1.1.11"), false,
+                   (1 << TunnelType::MPLS_GRE));
+
+    len = uclient.Recv(rcv_msg, sizeof(rcv_msg));
+    ValidateRcvdMessage(rcv_msg, len, 34, "10.1.1.11", "add");
+
+    CreateTunnelNH(agent_->fabric_vrf_name(), agent_->router_id(),
+                   Ip4Address::from_string("10.1.1.12"), false,
+                   (1 << TunnelType::MPLS_UDP));
+
+    len = uclient.Recv(rcv_msg, sizeof(rcv_msg));
+    ValidateRcvdMessage(rcv_msg, len, 34, "10.1.1.12", "add");
+
+    client_->WaitForIdle();
+
+    WAIT_FOR(100, 100, (TunnelNHFind(Ip4Address::from_string("10.1.1.10"),
+                                     false, TunnelType::MPLS_UDP) == true));
+
+    WAIT_FOR(100, 100, (TunnelNHFind(Ip4Address::from_string("10.1.1.11"),
+                                     false, TunnelType::MPLS_GRE) == true));
+
+    WAIT_FOR(100, 100, (TunnelNHFind(Ip4Address::from_string("10.1.1.12"),
+                                     false, TunnelType::MPLS_UDP) == true));
+
+    DeleteTunnelNH(agent_->fabric_vrf_name(), agent_->router_id(),
+                   Ip4Address::from_string("10.1.1.10"), false,
+                   (1 << TunnelType::MPLS_UDP));
+
+    len = uclient.Recv(rcv_msg, sizeof(rcv_msg));
+    ValidateRcvdMessage(rcv_msg, len, 34, "10.1.1.10", "del");
+
+    DeleteTunnelNH(agent_->fabric_vrf_name(), agent_->router_id(),
+                   Ip4Address::from_string("10.1.1.11"), false,
+                   (1 << TunnelType::MPLS_GRE));
+
+    len = uclient.Recv(rcv_msg, sizeof(rcv_msg));
+    ValidateRcvdMessage(rcv_msg, len, 34, "10.1.1.11", "del");
+
+    DeleteTunnelNH(agent_->fabric_vrf_name(), agent_->router_id(),
+                   Ip4Address::from_string("10.1.1.12"), false,
+                   (1 << TunnelType::MPLS_UDP));
+
+    len = uclient.Recv(rcv_msg, sizeof(rcv_msg));
+    ValidateRcvdMessage(rcv_msg, len, 34, "10.1.1.12", "del");
+
+    client_->WaitForIdle();
+
+    DelEncapList(agent_);
+    client_->WaitForIdle();
+}
+
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    int ret = RUN_ALL_TESTS();
+    return ret;
+}

--- a/src/vnsw/agent/nexthop_server/test/vnswa_cfg.ini
+++ b/src/vnsw/agent/nexthop_server/test/vnswa_cfg.ini
@@ -1,0 +1,131 @@
+#
+# Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+#
+# Vnswad configuration options
+#
+
+[CONTROL-NODE]
+# IP address to be used to connect to control-node. If IP is not configured
+# for server1, value provided by discovery service will be used.
+server=127.0.0.1
+
+[DEFAULT]
+# IP address and port to be used to connect to collector. If these are not
+# configured, value provided by discovery service will be used. Multiple
+# IP:port strings separated by space can be provided
+# collectors=127.0.0.1:8086
+
+# Aging time for flow-records in seconds
+# flow_cache_timeout=0
+
+# Hostname of compute-node. If this is not configured value from `hostname`
+# will be taken
+# hostname=
+
+# Http server port for inspecting vnswad state (useful for debugging)
+# http_server_port=8085
+
+# Category for logging. Default value is '*'
+# log_category=
+
+# Local log file name
+log_file=vrouter.log
+
+# Log severity levels. Possible values are SYS_EMERG, SYS_ALERT, SYS_CRIT,
+# SYS_ERR, SYS_WARN, SYS_NOTICE, SYS_INFO and SYS_DEBUG. Default is SYS_DEBUG
+# log_level=SYS_DEBUG
+
+# Enable/Disable local file logging. Possible values are 0 (disable) and 1 (enable)
+# log_local=0
+
+# Encapsulation type for tunnel. Possible values are MPLSoGRE, MPLSoUDP, VXLAN
+# tunnel_type=
+
+# Execute agent in headless mode where it does not flush config and route on losing
+# connection with control node. In turn it continues with last good config.
+# Possible values are true and false
+# headless=
+
+[DISCOVERY]
+# IP address of discovery server
+# server=10.204.217.52
+
+# Number of control-nodes info to be provided by Discovery service. Possible
+# values are 1 and 2
+# max_control_nodes=1
+
+[DNS]
+# IP address and port to be used to connect to dns-node. Maximum of 2 IP
+# addresses (separated by a space) can be provided. If no IP is configured then
+# the value provided by discovery service will be used.
+server=127.0.0.1:53
+
+[HYPERVISOR]
+# Hypervisor type. Possible values are kvm, xen and vmware
+# type=kvm
+
+# Link-local IP address and prefix in ip/prefix_len format (for xen)
+# xen_ll_ip=
+
+# Link-local interface name when hypervisor type is Xen
+# xen_ll_interface=
+
+# Physical interface name when hypervisor type is vmware
+# vmware_physical_interface=
+
+[FLOWS]
+# Maximum flows allowed per VM (given as % of maximum system flows)
+max_vm_flows=100
+# Maximum number of link-local flows allowed across all VMs
+max_system_linklocal_flows=3
+# Maximum number of link-local flows allowed per VM
+max_vm_linklocal_flows=2
+
+[METADATA]
+# Shared secret for metadata proxy service
+metadata_proxy_secret=contrail
+
+[NETWORKS]
+# control-channel IP address used by WEB-UI to connect to vnswad to fetch
+# required information
+# control_network_ip=
+
+[VIRTUAL-HOST-INTERFACE]
+# name of virtual host interface
+name=vhost0
+
+# IP address and prefix in ip/prefix_len format
+ip=10.1.1.1/24
+
+# Gateway IP address for virtual host
+gateway=10.1.1.254
+
+# Physical interface name to which virtual host interface maps to
+physical_interface=vnet0
+
+[GATEWAY-0]
+# Name of the routing_instance for which the gateway is being configured
+# routing_instance=default-domain:admin:public:public
+
+# Gateway interface name
+# interface=vgw
+
+# Virtual network ip blocks for which gateway service is required.
+# ip_blocks=1.1.1.1/24
+
+[GATEWAY-1]
+# Name of the routing_instance for which the gateway is being configured
+# routing_instance=default-domain:admin:public1:public1
+
+# Gateway interface name
+# interface=vgw1
+
+# Virtual network ip blocks for which gateway service is required.
+# ip_blocks=2.2.1.0/24, 2.2.2.0/24
+
+# Routes to be exported in routing_instance
+# routes= 10.10.10.1/24, 11.11.11.1/24
+
+[NEXTHOP-SERVER]
+endpoint=/tmp/contrail-nhserv.socket
+add_pid=1

--- a/src/vnsw/agent/oper/operdb_init.cc
+++ b/src/vnsw/agent/oper/operdb_init.cc
@@ -35,6 +35,7 @@
 #include <oper/loadbalancer.h>
 #include <oper/physical_device.h>
 #include <oper/physical_device_vn.h>
+#include <nexthop_server/nexthop_manager.h>
 
 using boost::assign::map_list_of;
 using boost::assign::list_of;
@@ -195,6 +196,9 @@ void OperDB::Init() {
     }
     instance_manager_->Initialize(agent_->db(), agent_->agent_signal(),
                                    netns_cmd, docker_cmd, netns_workers, netns_timeout);
+    if (nexthop_manager_.get()) {
+        nexthop_manager_->Initialize(agent_->db());
+    }
 }
 
 void OperDB::RegisterDBClients() {
@@ -213,7 +217,12 @@ OperDB::OperDB(Agent *agent)
               AgentObjectFactory::Create<IFMapDependencyManager>(
                   agent->db(), agent->cfg()->cfg_graph())),
           instance_manager_(
-              AgentObjectFactory::Create<InstanceManager>(agent)) {
+                  AgentObjectFactory::Create<InstanceManager>(agent)) {
+    if (agent_->params() &&
+        agent_->params()->nexthop_server_endpoint().length() > 0) {
+        nexthop_manager_.reset(new NexthopManager(agent_->event_manager(),
+                               agent->params()->nexthop_server_endpoint()));
+    }
 }
 
 OperDB::~OperDB() {
@@ -221,6 +230,9 @@ OperDB::~OperDB() {
 
 void OperDB::Shutdown() {
     instance_manager_->Terminate();
+    if (nexthop_manager_.get()) {
+        nexthop_manager_->Terminate();
+    }
     dependency_manager_->Terminate();
     global_vrouter_.reset();
 

--- a/src/vnsw/agent/oper/operdb_init.h
+++ b/src/vnsw/agent/oper/operdb_init.h
@@ -17,6 +17,7 @@ class PathPreferenceModule;
 class IFMapDependencyManager;
 class MulticastHandler;
 class InstanceManager;
+class NexthopManager;
 
 class OperDB {
 public:
@@ -45,6 +46,9 @@ public:
     DomainConfig *domain_config_table() {
         return domain_config_.get();
     }
+    NexthopManager *nexthop_manager() {
+      return nexthop_manager_.get();
+    }
 
 private:
     OperDB();
@@ -56,6 +60,7 @@ private:
     std::auto_ptr<IFMapDependencyManager> dependency_manager_;
     std::auto_ptr<InstanceManager> instance_manager_;
     std::auto_ptr<DomainConfig> domain_config_;
+    std::auto_ptr<NexthopManager> nexthop_manager_;
     DISALLOW_COPY_AND_ASSIGN(OperDB);
 };
 #endif

--- a/src/vnsw/agent/test/test_cmn_util.h
+++ b/src/vnsw/agent/test/test_cmn_util.h
@@ -47,7 +47,10 @@ void DelLink(const char *node_name1, const char *name1, const char *node_name2,
 void AddNode(const char *node_name, const char *name, int id);
 void AddNode(const char *node_name, const char *name, int id, const char *attr,
              bool admin_state = true);
+void AddNode(Agent *agent, const char *node_name, const char *name, int id,
+             const char *attr, bool admin_state = true);
 void DelNode(const char *node_name, const char *name);
+void DelNode(Agent *agent, const char *node_name, const char *name);
 void IntfSyncMsg(PortInfo *input, int id);
 void IntfCfgAdd(int intf_id, const string &name, const string ipaddr,
                 int vm_id, int vn_id, const string &mac, uint16_t vlan,
@@ -324,7 +327,10 @@ bool FindNH(NextHopKey *key);
 NextHop *GetNH(NextHopKey *key);
 bool VmPortServiceVlanCount(int id, unsigned int count);
 void AddEncapList(const char *encap1, const char *encap2, const char *encap3);
+void AddEncapList(Agent *agent, const char *encap1, const char *encap2,
+                  const char *encap3);
 void DelEncapList();
+void DelEncapList(Agent *agent);
 void VxLanNetworkIdentifierMode(bool config);
 int MplsToVrfId(int label);
 void AddInterfaceRouteTable(const char *name, int id, TestIp4Prefix *addr, 

--- a/src/vnsw/agent/test/test_util.cc
+++ b/src/vnsw/agent/test/test_util.cc
@@ -329,6 +329,22 @@ void AddNode(const char *node_name, const char *name, int id,
     return;
 }
 
+// admin_state is true by default
+void AddNode(Agent *agent, const char *node_name, const char *name, int id,
+             const char *attr, bool admin_state) {
+    char buff[10240];
+    int len = 0;
+
+    AddXmlHdr(buff, len);
+    AddNodeString(buff, len, node_name, name, id, attr, admin_state);
+    AddXmlTail(buff, len);
+    pugi::xml_document xdoc_;
+    pugi::xml_parse_result result = xdoc_.load(buff);
+    EXPECT_TRUE(result);
+    agent->ifmap_parser()->ConfigParse(xdoc_.first_child(), 0);
+    return;
+}
+
 void AddLinkNode(const char *node_name, const char *name, const char *attr) {
     char buff[1024];
     int len = 0;
@@ -355,6 +371,20 @@ void DelNode(const char *node_name, const char *name) {
     pugi::xml_parse_result result = xdoc_.load(buff);
     EXPECT_TRUE(result);
     Agent::GetInstance()->ifmap_parser()->ConfigParse(xdoc_.first_child(), 0);
+    return;
+}
+
+void DelNode(Agent *agent, const char *node_name, const char *name) {
+    char buff[1024];
+    int len = 0;
+
+    DelXmlHdr(buff, len);
+    DelNodeString(buff, len, node_name, name);
+    DelXmlTail(buff, len);
+    pugi::xml_document xdoc_;
+    pugi::xml_parse_result result = xdoc_.load(buff);
+    EXPECT_TRUE(result);
+    agent->ifmap_parser()->ConfigParse(xdoc_.first_child(), 0);
     return;
 }
 
@@ -1888,8 +1918,33 @@ void AddEncapList(const char *encap1, const char *encap2, const char *encap3) {
     AddNode("global-vrouter-config", "vrouter-config", 1, str.str().c_str());
 }
 
+void AddEncapList(Agent *agent, const char *encap1, const char *encap2,
+                  const char *encap3) {
+    std::stringstream str;
+    str << "<encapsulation-priorities>" << endl;
+    if (encap1) {
+        str << "    <encapsulation>" << encap1 << "</encapsulation>";
+    }
+
+    if (encap2) {
+        str << "    <encapsulation>" << encap2 << "</encapsulation>";
+    }
+
+    if (encap3) {
+        str << "    <encapsulation>" << encap3 << "</encapsulation>";
+    }
+    str << "</encapsulation-priorities>";
+
+    AddNode(agent, "global-vrouter-config", "vrouter-config", 1,
+            str.str().c_str());
+}
+
 void DelEncapList() {
     DelNode("global-vrouter-config", "vrouter-config");
+}
+
+void DelEncapList(Agent *agent) {
+    DelNode(agent, "global-vrouter-config", "vrouter-config");
 }
 
 void send_icmp(int fd, uint8_t smac, uint8_t dmac, uint32_t sip, uint32_t dip) {


### PR DESCRIPTION
Enable vrouter agent to send notification about tunnel nexthops to interested clients. This is implemented as a generic server framework within vrouter agent that accepts registrations from clients over a Unix domain socket. Anytime a tunnel nexthop is added or deleted, a notification message is sent to each client containing the nexthop and the action (add or delete).

Change-Id: I1c412b062377fe91022d847cf84bd023a4a338bc