### PR TITLE
Pass sandesh from opserver to discoverClient

### DIFF
--- a/src/opserver/opserver.py
+++ b/src/opserver/opserver.py
@@ -444,6 +444,7 @@ class OpServer(object):
             self._args.disc_server_ip,
             self._args.disc_server_port,
             ModuleNames[Module.OPSERVER])
+        self.disc.set_sandesh(sandesh_global)
         self._logger.info("Disc Publish to %s : %d - %s"
                           % (self._args.disc_server_ip,
                              self._args.disc_server_port, str(data)))


### PR DESCRIPTION
Currently, when the opserver uses the discoverClient,
the logs are not captured. Specifically, in my case,
this caused the following helpful log messages:

__default__ [SYS_INFO]: discClientLog: connection error or failed to publish

to never show up in my contrail-analytics logs.

A sendeesh object must be passed explicitly to the discoveryClient
in order for logging to work with its set_sandesh method.

This patch ensures that the global sendeesh object is passed
from the opserver to the discoveryClient so that its log messages
are captured.