### PR TITLE
BgpXmppChannel::XmppPeer : public IPeer :: ToString()

### DIFF
--- a/src/bgp/bgp_xmpp_channel.cc
+++ b/src/bgp/bgp_xmpp_channel.cc
@@ -2797,13 +2797,10 @@ void BgpXmppChannelManager::XmppHandleChannelEvent(XmppChannel *channel,
             BGP_LOG_PEER(Message, bgp_xmpp_channel->Peer(),
                          Sandesh::LoggingUtLevel(), BGP_LOG_FLAG_SYSLOG,
                          BGP_PEER_DIR_IN,
-                         "Received XmppChannel down event");
+                         "Received XmppChannel NOT_READY event");
 
             // Trigger closure of this channel
             bgp_xmpp_channel->Close();
-        } else {
-            BGP_LOG_NOTICE(BgpMessage, BGP_LOG_FLAG_ALL,
-                    "Peer not found on channel not ready event");
         }
     }
 }

--- a/src/xmpp/sandesh/xmpp_client_server_sandesh.sandesh
+++ b/src/xmpp/sandesh/xmpp_client_server_sandesh.sandesh
@@ -17,6 +17,11 @@ systemlog sandesh ClientOpenFail {
     2: string error_message
 }
 
+trace sandesh ClientOpenFailTrace {
+    1: "Xmpp Client : open failed"
+    2: string error_message
+}
+
 /**
  * @description: XMPP socket option setting failure
  * @severity: WARNING
@@ -24,6 +29,11 @@ systemlog sandesh ClientOpenFail {
  * @action: Check for kernel version and its ability to support the socket option that failed. Moving to a different kernel via kernel upgrade might help in working around this issue
  */
 systemlog sandesh SetSockOptFail {
+    1: "Xmpp Client: set_option: "
+    2: string error_message
+}
+
+trace sandesh SetSockOptFailTrace {
     1: "Xmpp Client: set_option: "
     2: string error_message
 }
@@ -39,6 +49,11 @@ systemlog sandesh ServerOpenFail {
     2: string error_message
 }
 
+trace sandesh ServerOpenFailTrace {
+    1: "Xmpp Server : open failed"
+    2: string error_message
+}
+
 /**
  * @description: XMPP Server socket bind operation failure
  * @severity: WARNING
@@ -46,6 +61,11 @@ systemlog sandesh ServerOpenFail {
  * @action: Check if another/duplicate process is already using the same port using netstat and lsof command line tools. If found, kill such offending processes and restart the daemon. If the port is used by another application legitimately, try changing the xmpp server port to a different unused port in /etc/contrail/contrail-control.conf
  */
 systemlog sandesh ServerBindFailure {
+    1: "Bind failure: ";
+    2: string error_message;
+}
+
+trace sandesh ServerBindFailureTrace {
     1: "Bind failure: ";
     2: string error_message;
 }
@@ -61,6 +81,11 @@ systemlog sandesh ServerKeepAliveFailure {
     2: string error_message;
 }
 
+trace sandesh ServerKeepAliveFailureTrace {
+    1: "Tcp KeepAlive failure: ";
+    2: string error_message;
+}
+
 /**
  * @description: XMPP Connection created
  * @severity: DEBUG
@@ -70,11 +95,21 @@ systemlog sandesh XmppCreateConnection {
     2: string to;
 }
 
+trace sandesh XmppCreateConnectionTrace {
+    1: "Xmpp creating dynamic channel"
+    2: string to;
+}
+
 /**
  * @description: XMPP Connection deleted
  * @severity: DEBUG
  */
 systemlog sandesh XmppDeleteConnection {
+    1: "Xmpp deleting dynamic channel"
+    2: string to;
+}
+
+trace sandesh XmppDeleteConnectionTrace {
     1: "Xmpp deleting dynamic channel"
     2: string to;
 }

--- a/src/xmpp/sandesh/xmpp_message_sandesh.sandesh
+++ b/src/xmpp/sandesh/xmpp_message_sandesh.sandesh
@@ -21,6 +21,15 @@ systemlog sandesh XmppConnectionCreate {
     6: string to;
 }
 
+trace sandesh XmppConnectionCreateTrace {
+    1: "Created Xmpp ";
+    2: string type;
+    3: " connection from ";
+    4: string from;
+    5: " To : ";
+    6: string to;
+}
+
 /**
  * @description: XMPP Session deletion event
  * @severity: DEBUG
@@ -28,6 +37,15 @@ systemlog sandesh XmppConnectionCreate {
  * @action: None
  */
 systemlog sandesh XmppSessionDelete {
+    1: "Delete Xmpp Session";
+    2: string type;
+    3: " connection from ";
+    4: string from;
+    5: " To : ";
+    6: string to;
+}
+
+trace sandesh XmppSessionDeleteTrace {
     1: "Delete Xmpp Session";
     2: string type;
     3: " connection from ";
@@ -46,6 +64,10 @@ systemlog sandesh XmppIqMessageInvalid {
     1: "Error: Mismatch in associated previous message"
 }
 
+trace sandesh XmppIqMessageInvalidTrace {
+    1: "Error: Mismatch in associated previous message"
+}
+
 /**
  * @description: XMPP IQ message parsing failure
  * @severity: WARNING
@@ -53,7 +75,11 @@ systemlog sandesh XmppIqMessageInvalid {
  * @action: Check logs from offending contrail-vrouter-agent which has sent incorrect or malformed xmpp iq message. Peer clear might help as a work around.
  */
 systemlog sandesh XmppIqMessageParseFail {
-    1: "Iq message parse failed" 
+    1: "Iq message parse failed"
+}
+
+trace sandesh XmppIqMessageParseFailTrace {
+    1: "Iq message parse failed"
 }
 
 /**
@@ -63,7 +89,11 @@ systemlog sandesh XmppIqMessageParseFail {
  * @action: Check logs from offending contrail-vrouter-agent which has sent incorrect or malformed xmpp chat message. Peer clear might help as a work around.
  */
 systemlog sandesh XmppChatMessageParseFail {
-    1: "Chat message parse failed" 
+    1: "Chat message parse failed"
+}
+
+trace sandesh XmppChatMessageParseFailTrace {
+    1: "Chat message parse failed"
 }
 
 /**
@@ -73,6 +103,13 @@ systemlog sandesh XmppChatMessageParseFail {
  * @action: Check logs from offending contrail-vrouter-agent which has sent incorrect or malformed xmpp message. Peer clear might help as a work around.
  */
 systemlog sandesh XmppBadMessage {
+    1: string type;
+    2: "Begin Message(";
+    3: string message;
+    4: ")End Message";
+}
+
+trace sandesh XmppBadMessageTrace {
     1: string type;
     2: "Begin Message(";
     3: string message;
@@ -90,11 +127,21 @@ systemlog sandesh XmppSslHandShakeMessage {
     2: string error;
 }
 
+trace sandesh XmppSslHandShakeMessageTrace {
+    1: string type;
+    2: string error;
+}
+
 /**
  * @description: XMPP HandShake Failed
  * @severity: ALERT
  */
 systemlog sandesh XmppSslHandShakeFailure {
+    1: string type;
+    2: string error;
+}
+
+trace sandesh XmppSslHandShakeFailureTrace {
     1: string type;
     2: string error;
 }
@@ -109,6 +156,10 @@ systemlog sandesh XmppIqCollectionError {
     1: "Error: no associated previous IQ message for this collection"
 }
 
+trace sandesh XmppIqCollectionErrorTrace {
+    1: "Error: no associated previous IQ message for this collection"
+}
+
 /**
  * @description: XMPP IQ message reception event
  * @severity: DEBUG
@@ -116,6 +167,21 @@ systemlog sandesh XmppIqCollectionError {
  * @action: None
  */
 systemlog sandesh XmppIqMessageProcess {
+    1: "Received IQ message for node:";
+    2: string node;
+    3: "Action: ";
+    4: string action;
+    5: "From: ";
+    6: string from;
+    7: "To: ";
+    8: string to;
+    9: "ID: ";
+    10: string id;
+    11: "SubType: ";
+    12: string sub_type;
+}
+
+trace sandesh XmppIqMessageProcessTrace {
     1: "Received IQ message for node:";
     2: string node;
     3: "Action: ";
@@ -145,6 +211,15 @@ systemlog sandesh XmppChatMessageProcess {
     6: string to;
 }
 
+trace sandesh XmppChatMessageProcessTrace {
+    1: "Received Chat message of type: "
+    2: i32 type;
+    3: "From ";
+    4: string from;
+    5: "To ";
+    6: string to;
+}
+
 /**
  * @description: XMPP Open message reception event
  * @severity: DEBUG
@@ -152,6 +227,13 @@ systemlog sandesh XmppChatMessageProcess {
  * @action: None
  */
 systemlog sandesh XmppRxOpenMessage {
+    1: "Received open message From: ";
+    2: string from;
+    3: " To: ";
+    4: string to;
+}
+
+trace sandesh XmppRxOpenMessageTrace {
     1: "Received open message From: ";
     2: string from;
     3: " To: ";
@@ -168,6 +250,10 @@ systemlog sandesh XmppRxStreamTlsRequired {
     1: "Received Tls Feature Required ";
 }
 
+trace sandesh XmppRxStreamTlsRequiredTrace {
+    1: "Received Tls Feature Required ";
+}
+
 /**
  * @description: XMPP TLS Start message reception event
  * @severity: DEBUG
@@ -178,6 +264,10 @@ systemlog sandesh XmppRxStreamStartTls {
     1: "Received Start Tls ";
 }
 
+trace sandesh XmppRxStreamStartTlsTrace {
+    1: "Received Start Tls ";
+}
+
 /**
  * @description: XMPP TLS Proceed message reception event
  * @severity: DEBUG
@@ -185,5 +275,9 @@ systemlog sandesh XmppRxStreamStartTls {
  * @action: None
  */
 systemlog sandesh XmppRxStreamProceed {
+    1: "Received Proceed Tls ";
+}
+
+trace sandesh XmppRxStreamProceedTrace {
     1: "Received Proceed Tls ";
 }

--- a/src/xmpp/sandesh/xmpp_state_machine_sandesh.sandesh
+++ b/src/xmpp/sandesh/xmpp_state_machine_sandesh.sandesh
@@ -31,6 +31,11 @@ systemlog sandesh XmppStateMachineDebug {
     2: string message;
 }
 
+trace sandesh XmppStateMachineDebugTrace {
+    1: string channel_type;
+    2: string message;
+}
+
 /**
  * @description: XMPP StateMachine related message
  * @severity: NOTICE
@@ -40,11 +45,26 @@ systemlog sandesh XmppStateMachineNotice {
     2: string message;
 }
 
+trace sandesh XmppStateMachineNoticeTrace {
+    1: string channel_type;
+    2: string message;
+}
+
 /**
  * @description: XMPP Event related message
  * @severity: NOTICE
  */
 systemlog sandesh XmppEventLog {
+    1: string channel_type;
+    2: string event;
+    3: "peer ip:";
+    4: string peer_address;
+    5: "(";
+    6: string local_address;
+    7: ")";
+}
+
+trace sandesh XmppEventLogTrace {
     1: string channel_type;
     2: string event;
     3: "peer ip:";
@@ -67,11 +87,29 @@ systemlog sandesh XmppOpen {
     6: string to;
 }
 
+trace sandesh XmppOpenTrace {
+    1: "Send Xmpp Open: ";
+    2: i32 length;
+    3: " bytes from: ";
+    4: string from;
+    5: " To: ";
+    6: string to;
+}
+
 /**
  * @description: XMPP OpenConfirm message send event
  * @severity: DEBUG
  */
 systemlog sandesh XmppOpenConfirm {
+    1: "Send Xmpp Open Confirm: ";
+    2: i32 length;
+    3: " bytes from: ";
+    4: string from;
+    5: " To: ";
+    6: string to;
+}
+
+trace sandesh XmppOpenConfirmTrace {
     1: "Send Xmpp Open Confirm: ";
     2: i32 length;
     3: " bytes from: ";
@@ -93,6 +131,15 @@ systemlog sandesh XmppControlMessage {
     6: string to;
 }
 
+trace sandesh XmppControlMessageTrace {
+    1: string message
+    2: i32 length;
+    3: " bytes from: ";
+    4: string from;
+    5: " To: ";
+    6: string to;
+}
+
 /**
  * @description: XMPP KeepAlive timer error
  * @severity: ERROR
@@ -106,11 +153,27 @@ systemlog sandesh XmppKeepaliveTimeError {
     4: string message;
 }
 
+trace sandesh XmppKeepaliveTimeErrorTrace {
+    1: "Xmpp Keepalive timer error: ";
+    2: string name;
+    3: "  ";
+    4: string message;
+}
+
 /**
  * @description: XMPP Close send event
  * @severity: DEBUG
  */
 systemlog sandesh XmppClose {
+    1: "Send Close: ";
+    2: i32 length;
+    3: " bytes from: ";
+    4: string from;
+    5: " To: ";
+    6: string to;
+}
+
+trace sandesh XmppCloseTrace {
     1: "Send Close: ";
     2: i32 length;
     3: " bytes from: ";
@@ -132,6 +195,15 @@ systemlog sandesh XmppConnectionDelete {
     6: string to;
 }
 
+trace sandesh XmppConnectionDeleteTrace {
+    1: "Deleted Xmpp ";
+    2: string type;
+    3: " connection from ";
+    4: string from;
+    5: " To : ";
+    6: string to;
+}
+
 /**
  * @description: XMPP Unknown event
  * @severity: WARNING
@@ -144,11 +216,25 @@ systemlog sandesh XmppUnknownEvent {
     3: i32 event;
 }
 
+trace sandesh XmppUnknownEventTrace {
+    1: string channel_type;
+    2: "Event :";
+    3: i32 event;
+}
+
 /**
  * @description: XMPP State Machine message discarded event
  * @severity: DEBUG
  */
 systemlog sandesh XmppUnconsumedEvent {
+    1: string channel_type;
+    2: "Unconsumed Event";
+    3: string event;
+    4: " in state ";
+    5: string state;
+}
+
+trace sandesh XmppUnconsumedEventTrace {
     1: string channel_type;
     2: "Unconsumed Event";
     3: string event;
@@ -168,6 +254,12 @@ systemlog sandesh XmppStateMachineUnsupportedMessage {
    3: i32 message_type;
 }
 
+trace sandesh XmppStateMachineUnsupportedMessageTrace {
+   1: "Xmpp message decode error ";
+   2: string channel_type;
+   3: i32 message_type;
+}
+
 /**
  * @description: XMPP State Machine timer expired event
  * @severity: DEBUG
@@ -179,11 +271,31 @@ systemlog sandesh XmppStateMachineTimerExpire {
     4: string state;
 }
 
+trace sandesh XmppStateMachineTimerExpireTrace {
+    1: string channel_type;
+    2: string f2;
+    3: "Expired in state: "
+    4: string state;
+}
+
 /**
  * @description: XMPP State Machine dequeue event
  * @severity: DEBUG
  */
 systemlog sandesh XmppStateMachineDequeueEvent {
+   1: "RECV Processing ";
+   2: string channel_type;
+   3: string event;
+   4: " In State ";
+   5: string state;
+   6: "peer";
+   7: string from;
+   8: "(";
+   9: string to;
+   10: ")"
+}
+
+trace sandesh XmppStateMachineDequeueEventTrace {
    1: "RECV Processing ";
    2: string channel_type;
    3: string event;

--- a/src/xmpp/xmpp_log.h
+++ b/src/xmpp/xmpp_log.h
@@ -26,6 +26,7 @@ do {                                                                           \
     if (LoggingDisabled()) break;                                              \
     obj::Send(g_vns_constants.CategoryNames.find(Category::XMPP)->second,      \
               SandeshLevel::SYS_ALERT, __FILE__, __LINE__, ##__VA_ARGS__);     \
+    XMPP_TRACE(obj##Trace, ##__VA_ARGS__);                                     \
 } while (false)
 
 #define XMPP_WARNING(obj, ...)                                                 \
@@ -33,6 +34,7 @@ do {                                                                           \
     if (LoggingDisabled()) break;                                              \
     obj::Send(g_vns_constants.CategoryNames.find(Category::XMPP)->second,      \
               SandeshLevel::SYS_WARN, __FILE__, __LINE__, ##__VA_ARGS__);      \
+    XMPP_TRACE(obj##Trace, ##__VA_ARGS__);                                     \
 } while (false)
 
 #define XMPP_NOTICE(obj, ...)                                                  \
@@ -40,6 +42,7 @@ do {                                                                           \
     if (LoggingDisabled()) break;                                              \
     obj::Send(g_vns_constants.CategoryNames.find(Category::XMPP)->second,      \
               SandeshLevel::SYS_NOTICE, __FILE__, __LINE__, ##__VA_ARGS__);    \
+    XMPP_TRACE(obj##Trace, ##__VA_ARGS__);                                     \
 } while (false)
 
 #define XMPP_INFO(obj, ...)                                                    \
@@ -47,6 +50,7 @@ do {                                                                           \
     if (LoggingDisabled()) break;                                              \
     obj::Send(g_vns_constants.CategoryNames.find(Category::XMPP)->second,      \
               SandeshLevel::SYS_INFO, __FILE__, __LINE__, ##__VA_ARGS__);      \
+    XMPP_TRACE(obj##Trace, ##__VA_ARGS__);                                     \
 } while (false)
 
 #define XMPP_DEBUG(obj, ...)                                                   \
@@ -54,13 +58,14 @@ do {                                                                           \
     if (LoggingDisabled()) break;                                              \
     obj::Send(g_vns_constants.CategoryNames.find(Category::XMPP)->second,      \
               SandeshLevel::SYS_DEBUG, __FILE__, __LINE__, ##__VA_ARGS__);     \
+    XMPP_TRACE(obj##Trace, ##__VA_ARGS__);                                     \
 } while (false)
 
 #define XMPP_UTDEBUG(obj, ...)                                                 \
 do {                                                                           \
     if (LoggingDisabled()) break;                                              \
     obj::Send(g_vns_constants.CategoryNames.find(Category::XMPP)->second,      \
-              Sandesh::LoggingUtLevel(), __FILE__, __LINE__, ##__VA_ARGS__);      \
+              Sandesh::LoggingUtLevel(), __FILE__, __LINE__, ##__VA_ARGS__);   \
 } while (false)
 
 #define XMPP_TRACE(obj, ...) do {                                              \

--- a/src/xmpp/xmpp_state_machine.cc
+++ b/src/xmpp/xmpp_state_machine.cc
@@ -1398,16 +1398,16 @@ void XmppStateMachine::ProcessStreamHeaderMessage(XmppSession *session,
                 if (ready) {
                     XmppStateMachine *sm =
                         endpoint->connection()->state_machine();
-                    XMPP_DEBUG(XmppDeleteConnection,
-                               "Delete old xmpp connection " +
-                               sm->session()->ToString() +
-                               " as a new connection as been initiated");
+                    XMPP_NOTICE(XmppDeleteConnection,
+                                "Delete old xmpp connection " +
+                                sm->session()->ToString() +
+                                " as a new connection as been initiated");
                     sm->Enqueue(xmsm::EvTcpClose(sm->session()));
                 }
 
-                XMPP_DEBUG(XmppDeleteConnection,
-                           "Drop new xmpp connection " + session->ToString() +
-                           " as current connection is still not deleted");
+                XMPP_NOTICE(XmppDeleteConnection,
+                            "Drop new xmpp connection " + session->ToString() +
+                            " as current connection is still not deleted");
                 ProcessEvent(xmsm::EvTcpClose(session));
                 delete msg;
                 return;
@@ -1718,8 +1718,8 @@ void XmppStateMachine::ResurrectOldConnection(XmppConnection *new_connection,
     XmppServer *server = dynamic_cast<XmppServer *>(new_connection->server());
     assert(server->IsPeerCloseGraceful());
 
-    XMPP_DEBUG(XmppCreateConnection, "Resurrect xmpp connection " +
-               new_session->ToString());
+    XMPP_NOTICE(XmppCreateConnection, "Resurrect xmpp connection " +
+                new_session->ToString());
 
     // Retrieve old XmppConnection and XmppStateMachine (to reuse)
     XmppConnection *old_xmpp_connection = connection_endpoint->connection();


### PR DESCRIPTION
    BgpXmppChannel::ToString()
        XmppChannel::ToString()
            XmppChannelMux::ToString()
                XmppConnection::ToString()
                    std::string XmppConnection::to_(config->ToAddr)

BgpXmppChannel::XmppPeer : public IPeer :: ToUVEKey()
    if (!channel_->connection())
        BgpXmppChannel::ToString()
    XmppConnection::ToUVEKey() =>
        from_ << ":" << endpoint().address()
        i.e.
        config->FromAddr << ":" << config->endpoint.address()
        i.e.
        config->FromAddr << ":" << session->remote_endpoint().address

BGP_LOG_PEER*() macros use IPeer::ToUVEKey()

XMPP_* macros do not have unified way
    Some log connection()->endpoint().address() and connection()->GetTo()
        i.e session->remote_endpoint().address and config->ToAddr
        config->ToAddr for Server is "" and Client is XmppInit::kControlNodeJID
                                      ("network-control@contrailsystems.com")
    Most use XmppSession::ToString() => TcpSession::String()=> TcpSession::name_
                             => local.address() + ":" + local.port() + ":" +
                                remote_.address() + ":" + remote_.port()

Change-Id: Ifdbb9125d7750e803ae67b2f50279926949ad019