### PR TITLE
vrouter-agent: fix crash when XMPP port is unspec

### DIFF
--- a/src/vnsw/agent/cmn/agent.cc
+++ b/src/vnsw/agent/cmn/agent.cc
@@ -371,13 +371,21 @@ void Agent::InitControllerList() {
     if (controller_list_.size() >= 1) {
         boost::split(servers, controller_list_[0], boost::is_any_of(":"));
         xs_addr_[0] = servers[0];
-        std::istringstream converter(servers[1]);
-        converter >> xs_port_[0];
+	if (servers.size() > 1) {
+	    std::istringstream converter(servers[1]);
+	    converter >> xs_port_[0];
+	} else {
+	    xs_port_[0] = XMPP_SERVER_PORT;
+	}
         if (controller_list_.size() >= 2) {
             boost::split(servers, controller_list_[1], boost::is_any_of(":"));
             xs_addr_[1] = servers[0];
-            std::istringstream converter2(servers[1]);
-            converter2 >> xs_port_[1];
+	    if (servers.size() > 1) {
+                std::istringstream converter2(servers[1]);
+                converter2 >> xs_port_[1];
+	    } else {
+	        xs_port_[1] = XMPP_SERVER_PORT;
+	    }
         }
     }
 }


### PR DESCRIPTION
If one omits XMPP port in CONTROL-NODE.servers parameter in the
vrouter-agent config file, the program would crash because it expects
it to be always present. The parser doesn't enforce this, however.

Fix by making XMPP port optional and defaulting to XMPP_SERVER_PORT
(5269) where appropriate.

Signed-off-by: Valentine Sinitsyn <valentine.sinitsyn@gmail.com>