### PR TITLE
ignore empty fpc instead of failing

### DIFF
--- a/src/config/fabric-ansible/ansible-playbooks/roles/wait_for_fpc_online/filter_plugins/fpc_filters.py
+++ b/src/config/fabric-ansible/ansible-playbooks/roles/wait_for_fpc_online/filter_plugins/fpc_filters.py
@@ -28,7 +28,7 @@ class FilterModule(object):
                 return False
             pic_slots = fpc.get('pic')
             if pic_slots is None:
-                return False
+                continue
             if isinstance(pic_slots, dict):
                 pic_slots = [pic_slots]
             for pic in pic_slots:


### PR DESCRIPTION
ZTP was failing by empty FPC, which should not fail.